### PR TITLE
Make 'uuagc' compile in GHC 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,22 @@ matrix:
   include:
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=2.0 GHCVER=8.2.2
       compiler: ": #GHC 8.2.2"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=2.2 GHCVER=8.4.4
       compiler: ": #GHC 8.4.4"
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=2.4 GHCVER=8.6.3
       compiler: ": #GHC 8.4.3"
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3,happy-1.19.5], sources: [hvr-ghc]}}
 #    - env: CABALVER=head GHCVER=head
 #      compiler: ": #GHC head"
 #      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,22 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
+    - env: CABALVER=1.18 GHCVER=7.8.4 HAPPYVER=1.19.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3
+    - env: CABALVER=1.22 GHCVER=7.10.3 HAPPYVER=1.19.5
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.2
+    - env: CABALVER=1.24 GHCVER=8.0.2 HAPPYVER=1.19.5
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.2.2
+    - env: CABALVER=2.0 GHCVER=8.2.2 HAPPYVER=1.19.5
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=8.4.4
+    - env: CABALVER=2.2 GHCVER=8.4.4 HAPPYVER=1.19.5
       compiler: ": #GHC 8.4.4"
       addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4 GHCVER=8.6.3
+    - env: CABALVER=2.4 GHCVER=8.6.3 HAPPYVER=1.19.5
       compiler: ": #GHC 8.4.3"
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3,happy-1.19.5], sources: [hvr-ghc]}}
 #    - env: CABALVER=head GHCVER=head
@@ -37,7 +37,7 @@ matrix:
 
 before_install:
  - unset CC
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:$PATH
 
 install:
  - cabal --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ install:
 script:
  - cd uuagc/trunk
  - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal install --only-dependencies
  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ before_cache:
 
 matrix:
   include:
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cd uuagc/trunk;
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     cd ../..;
    fi
 
 # snapshot package-db on cache miss

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - cd uuagc/trunk
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > ../../installplan.txt
  - cd ../..
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_cache:
 
 matrix:
   include:
-   - env: CABALVER=1.24 GHCVER=8.0.2
-     compiler: ": #GHC 8.0.2"
-     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
     - env: CABALVER=2.0 GHCVER=8.2.2
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+   - env: CABALVER=1.24 GHCVER=8.0.2
+     compiler: ": #GHC 8.0.2"
+     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.2
+      compiler: ": #GHC 8.2.2"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.4.4
+      compiler: ": #GHC 8.4.4"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.6.3
+      compiler: ": #GHC 8.4.3"
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
+#    - env: CABALVER=head GHCVER=head
+#      compiler: ": #GHC head"
+#      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cd uuagc/trunk
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - cd ../..
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - cd uuagc/trunk
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       compiler: ": #GHC 8.4.4"
       addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=2.4 GHCVER=8.6.3 HAPPYVER=1.19.5
-      compiler: ": #GHC 8.4.3"
+      compiler: ": #GHC 8.6.3"
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3,happy-1.19.5], sources: [hvr-ghc]}}
 #    - env: CABALVER=head GHCVER=head
 #      compiler: ": #GHC head"

--- a/uuagc/trunk/src-ag/Transform.ag
+++ b/uuagc/trunk/src-ag/Transform.ag
@@ -325,29 +325,29 @@ SEM AG
                            in   Seq.empty                                                 -- allow duplicate constructors, merging their fields
                              -- Seq.fromList . concat . map f . Map.toList $ @allConstrs  -- forbid duplicate constructors
 
-         loc.errs4       = let  f m s = Map.fold ((><) . snd) s m
-                           in Map.fold f Seq.empty @loc.allRulesErrs
+         loc.errs4       = let  f m s = Map.foldr ((><) . snd) s m
+                           in Map.foldr f Seq.empty @loc.allRulesErrs
 
-         loc.errs5       = let  f m s = Map.fold ((><) . snd) s m
-                           in Map.fold f Seq.empty @loc.allSigsErrs
+         loc.errs5       = let  f m s = Map.foldr ((><) . snd) s m
+                           in Map.foldr f Seq.empty @loc.allSigsErrs
 
-         loc.errs6       = let  f m s = Map.fold ((><) . snd) s m
-                           in Map.fold f Seq.empty @loc.allInstsErrs
+         loc.errs6       = let  f m s = Map.foldr ((><) . snd) s m
+                           in Map.foldr f Seq.empty @loc.allInstsErrs
 
-         loc.errs7       = let  f m s = Map.fold ((><) . snd) s m
-                           in Map.fold f Seq.empty @loc.allUniquesErrs
+         loc.errs7       = let  f m s = Map.foldr ((><) . snd) s m
+                           in Map.foldr f Seq.empty @loc.allUniquesErrs
 
-         loc.errs8       = let  f m s = Map.fold ((><) . snd) s m
-                           in Map.fold f Seq.empty @loc.allAugmentErrs
+         loc.errs8       = let  f m s = Map.foldr ((><) . snd) s m
+                           in Map.foldr f Seq.empty @loc.allAugmentErrs
 
-         loc.errs9       = let  f m s = Map.fold ((><) . snd) s m
-                           in Map.fold f Seq.empty @loc.allAroundsErrs
+         loc.errs9       = let  f m s = Map.foldr ((><) . snd) s m
+                           in Map.foldr f Seq.empty @loc.allAroundsErrs
 
-         loc.errs10      =  let  f m s = Map.fold ((><)) s m
-                            in Map.fold f Seq.empty @loc.allNamesErrs
+         loc.errs10      =  let  f m s = Map.foldr ((><)) s m
+                            in Map.foldr f Seq.empty @loc.allNamesErrs
 
-         loc.errs11      =  let f m s = Map.fold ((><) . snd) s m
-                            in Map.fold f Seq.empty @loc.allMergesErrs
+         loc.errs11      =  let f m s = Map.foldr ((><) . snd) s m
+                            in Map.foldr f Seq.empty @loc.allMergesErrs
 
          lhs.errors      = @elems.errors >< @errs1 >< @errs2 >< @errs3 >< @errs4 >< @errs5 >< @errs6 >< @errs7 >< @errs8 >< @errs9 >< @errs10 >< @errs11
 

--- a/uuagc/trunk/src-generated/Transform.hs
+++ b/uuagc/trunk/src-generated/Transform.hs
@@ -866,57 +866,57 @@ sem_AG_AG arg_elems_ = T_AG (return st2) where
    {-# LINE 328 "src-ag/Transform.ag" #-}
    rule33 = \ _allRulesErrs ->
                              {-# LINE 328 "src-ag/Transform.ag" #-}
-                             let  f m s = Map.fold ((><) . snd) s m
-                             in Map.fold f Seq.empty _allRulesErrs
+                             let  f m s = Map.foldr ((><) . snd) s m
+                             in Map.foldr f Seq.empty _allRulesErrs
                              {-# LINE 872 "dist/build/Transform.hs"#-}
    {-# INLINE rule34 #-}
    {-# LINE 331 "src-ag/Transform.ag" #-}
    rule34 = \ _allSigsErrs ->
                              {-# LINE 331 "src-ag/Transform.ag" #-}
-                             let  f m s = Map.fold ((><) . snd) s m
-                             in Map.fold f Seq.empty _allSigsErrs
+                             let  f m s = Map.foldr ((><) . snd) s m
+                             in Map.foldr f Seq.empty _allSigsErrs
                              {-# LINE 879 "dist/build/Transform.hs"#-}
    {-# INLINE rule35 #-}
    {-# LINE 334 "src-ag/Transform.ag" #-}
    rule35 = \ _allInstsErrs ->
                              {-# LINE 334 "src-ag/Transform.ag" #-}
-                             let  f m s = Map.fold ((><) . snd) s m
-                             in Map.fold f Seq.empty _allInstsErrs
+                             let  f m s = Map.foldr ((><) . snd) s m
+                             in Map.foldr f Seq.empty _allInstsErrs
                              {-# LINE 886 "dist/build/Transform.hs"#-}
    {-# INLINE rule36 #-}
    {-# LINE 337 "src-ag/Transform.ag" #-}
    rule36 = \ _allUniquesErrs ->
                              {-# LINE 337 "src-ag/Transform.ag" #-}
-                             let  f m s = Map.fold ((><) . snd) s m
-                             in Map.fold f Seq.empty _allUniquesErrs
+                             let  f m s = Map.foldr ((><) . snd) s m
+                             in Map.foldr f Seq.empty _allUniquesErrs
                              {-# LINE 893 "dist/build/Transform.hs"#-}
    {-# INLINE rule37 #-}
    {-# LINE 340 "src-ag/Transform.ag" #-}
    rule37 = \ _allAugmentErrs ->
                              {-# LINE 340 "src-ag/Transform.ag" #-}
-                             let  f m s = Map.fold ((><) . snd) s m
-                             in Map.fold f Seq.empty _allAugmentErrs
+                             let  f m s = Map.foldr ((><) . snd) s m
+                             in Map.foldr f Seq.empty _allAugmentErrs
                              {-# LINE 900 "dist/build/Transform.hs"#-}
    {-# INLINE rule38 #-}
    {-# LINE 343 "src-ag/Transform.ag" #-}
    rule38 = \ _allAroundsErrs ->
                              {-# LINE 343 "src-ag/Transform.ag" #-}
-                             let  f m s = Map.fold ((><) . snd) s m
-                             in Map.fold f Seq.empty _allAroundsErrs
+                             let  f m s = Map.foldr ((><) . snd) s m
+                             in Map.foldr f Seq.empty _allAroundsErrs
                              {-# LINE 907 "dist/build/Transform.hs"#-}
    {-# INLINE rule39 #-}
    {-# LINE 346 "src-ag/Transform.ag" #-}
    rule39 = \ _allNamesErrs ->
                               {-# LINE 346 "src-ag/Transform.ag" #-}
-                              let  f m s = Map.fold ((><)) s m
-                              in Map.fold f Seq.empty _allNamesErrs
+                              let  f m s = Map.foldr ((><)) s m
+                              in Map.foldr f Seq.empty _allNamesErrs
                               {-# LINE 914 "dist/build/Transform.hs"#-}
    {-# INLINE rule40 #-}
    {-# LINE 349 "src-ag/Transform.ag" #-}
    rule40 = \ _allMergesErrs ->
                               {-# LINE 349 "src-ag/Transform.ag" #-}
-                              let f m s = Map.fold ((><) . snd) s m
-                              in Map.fold f Seq.empty _allMergesErrs
+                              let f m s = Map.foldr ((><) . snd) s m
+                              in Map.foldr f Seq.empty _allMergesErrs
                               {-# LINE 921 "dist/build/Transform.hs"#-}
    {-# INLINE rule41 #-}
    {-# LINE 352 "src-ag/Transform.ag" #-}

--- a/uuagc/trunk/src/KennedyWarren.hs
+++ b/uuagc/trunk/src/KennedyWarren.hs
@@ -20,6 +20,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Map.Strict as MapStrict
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.IntSet (IntSet)
@@ -400,7 +401,7 @@ addChildVisit (VGProd (VGEdge edg, p)) ide (VGEdge vs) = do
   let (VGNode from,vgto) = imLookup vs edges -- from must be equal to the current state
   childvs <- gets vgChildVisits
   let rchildv = imLookup edg childvs
-  vgInST $ modifySTRef rchildv $ Map.insertWith' (++) (ide,p) [vgto]
+  vgInST $ modifySTRef rchildv $ MapStrict.insertWith (++) (ide,p) [vgto]
   ndis <- gets vgNDI
   let rndi = imLookup from ndis
   ndi <- vgInST $ readSTRef rndi


### PR DESCRIPTION
There are the changes required to make `uuagc` compile on GHC 8.6.x. The source of the problems is the new version of `containers`, which has deprecated some functions.