### PR TITLE
Make uuagc compile with GHC 8.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.dyn_o
 *.dyn_hi
 uuagc/trunk/dist/*
+dist-newstyle/

--- a/uuagc/trunk/cabal-plugin/src/Distribution/Simple/UUAGC/UUAGC.hs
+++ b/uuagc/trunk/cabal-plugin/src/Distribution/Simple/UUAGC/UUAGC.hs
@@ -6,7 +6,7 @@ module Distribution.Simple.UUAGC.UUAGC(uuagcUserHook,
                                        uuagcFromString
                                       ) where
 
-import Distribution.Simple.BuildPaths (autogenModulesDir)
+-- import Distribution.Simple.BuildPaths (autogenComponentModulesDir)
 import Debug.Trace
 import Distribution.Simple
 import Distribution.Simple.PreProcess
@@ -104,13 +104,13 @@ uuagcLibUserHook :: ([String] -> FilePath -> IO (ExitCode, [FilePath])) -> UserH
 uuagcLibUserHook uuagc = hooks where
   hooks = simpleUserHooks { hookedPreProcessors = ("ag", ag):("lag",ag):knownSuffixHandlers
                           , buildHook = uuagcBuildHook uuagc
-                          , sDistHook = uuagcSDistHook uuagc
+--                          , sDistHook = uuagcSDistHook uuagc
                           }
   ag = uuagc' uuagc
 
 originalPreBuild  = preBuild simpleUserHooks
 originalBuildHook = buildHook simpleUserHooks
-originalSDistHook = sDistHook simpleUserHooks
+--originalSDistHook = sDistHook simpleUserHooks
 
 putErrorInfo :: Handle -> IO ()
 putErrorInfo h = hGetContents h >>= hPutStr stderr
@@ -188,21 +188,21 @@ getOptionsFromClass classes fOpt =
                                                    ++ show fClass
                                                    ++ " is not defined."
 
-uuagcSDistHook :: ([String] -> FilePath -> IO (ExitCode, [FilePath]))
-     -> PackageDescription
-     -> Maybe LocalBuildInfo
-     -> UserHooks
-     -> SDistFlags
-     -> IO ()
-uuagcSDistHook uuagc pd mbLbi uh df = do
-  {-
-  case mbLbi of
-    Nothing -> warn normal "sdist: the local buildinfo was not present. Skipping AG initialization. Dist may fail."
-    Just lbi -> let classesPath = buildDir lbi </> agClassesFile
-                in commonHook uuagc classesPath pd lbi (sDistVerbosity df)
-  originalSDistHook pd mbLbi uh df
-  -}
-  originalSDistHook pd mbLbi (uh { hookedPreProcessors = ("ag", nouuagc):("lag",nouuagc):knownSuffixHandlers }) df  -- bypass preprocessors
+-- uuagcSDistHook :: ([String] -> FilePath -> IO (ExitCode, [FilePath]))
+--      -> PackageDescription
+--      -> Maybe LocalBuildInfo
+--      -> UserHooks
+--      -> SDistFlags
+--      -> IO ()
+-- uuagcSDistHook uuagc pd mbLbi uh df = do
+--   {-
+--   case mbLbi of
+--     Nothing -> warn normal "sdist: the local buildinfo was not present. Skipping AG initialization. Dist may fail."
+--     Just lbi -> let classesPath = buildDir lbi </> agClassesFile
+--                 in commonHook uuagc classesPath pd lbi (sDistVerbosity df)
+--   originalSDistHook pd mbLbi uh df
+--   -}
+--   originalSDistHook pd mbLbi (uh { hookedPreProcessors = ("ag", nouuagc):("lag",nouuagc):knownSuffixHandlers }) df  -- bypass preprocessors
 
 uuagcBuildHook
   :: ([String] -> FilePath -> IO (ExitCode, [FilePath]))

--- a/uuagc/trunk/diagrams/uuagc-diagrams.cabal
+++ b/uuagc/trunk/diagrams/uuagc-diagrams.cabal
@@ -16,6 +16,6 @@ library
   exposed-modules:     UU.UUAGC.Diagrams
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8, diagrams-lib >= 1.1, SVGFonts >= 1.4
+  build-depends:       base >=4.7 && <4.15, diagrams-lib >= 1.4 && <1.5, SVGFonts >= 1.7 && <1.8
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/uuagc/trunk/uuagc.cabal
+++ b/uuagc/trunk/uuagc.cabal
@@ -33,6 +33,8 @@ flag with-loag
    default: False
    manual: True
 
+custom-setup
+  setup-depends: base, Cabal
 
 executable uuagc
    build-depends: uuagc-cabal >= 1.0.2.0


### PR DESCRIPTION
This disables the sdist hook, because cabal new-style has removed that field and I do not know what should replace it.

This also fixes `uuagc-diagrams` to work with the latest versions of its dependencies. I'm not 100% confident that `shaftT` and `shaftB` still work correctly.

Note that i have also used the `unsafePerformIO` trick for a global variable `lin2'` that loads the font once at the start of the program.

This should fix #3.