### PR TITLE
Expand tabs and make compiling with -DEXTERNAL_UUAGC work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.dyn_hi
 uuagc/trunk/dist/*
 dist-newstyle/
+cabal.project.local

--- a/uuagc/trunk/doc/ag-tutorial/gen/src/PictGen.ag
+++ b/uuagc/trunk/doc/ag-tutorial/gen/src/PictGen.ag
@@ -240,7 +240,7 @@ SEM Prod
 
 SEM Sym
   | Nont
-      tp.ctxtNm  	 = ""
+      tp.ctxtNm          = ""
 
 --
 -- Width calculation

--- a/uuagc/trunk/src-ag/AG2AspectAG.ag
+++ b/uuagc/trunk/src-ag/AG2AspectAG.ag
@@ -124,7 +124,7 @@ ATTR Grammar Nonterminals Nonterminal Productions Production Children Child Rule
 ATTR Grammar [ | | imp USE {>-<} {empty} : PP_Doc ]
 
 SEM Grammar
-  | Grammar  		lhs     .  	imp    	=  "import Language.Grammars.AspectAG" >-<
+  | Grammar             lhs     .       imp     =  "import Language.Grammars.AspectAG" >-<
                                                    "import Language.Grammars.AspectAG.Derive" >-<
                                                    "import Data.HList.Label4" >-<
                                                    "import Data.HList.TypeEqGeneric1" >-<
@@ -137,7 +137,7 @@ SEM Grammar
 ATTR Grammar [ | | pp USE {>-<} {empty} : PP_Doc ]
 
 SEM Grammar
-  | Grammar  		lhs     .  	pp    	=  (if dataTypes @lhs.options
+  | Grammar             lhs     .       pp      =  (if dataTypes @lhs.options
                                                    then  "-- datatypes"               >-< @nonts.ppD >-<
                                                          "-- labels"                  >-< @nonts.ppL
                                                    else  empty)
@@ -170,16 +170,16 @@ SEM Grammar
 -- data definitions
 
 SEM Nonterminal
-  | Nonterminal		loc       .  	ppNt   	 =  pp @nt
+  | Nonterminal         loc       .     ppNt     =  pp @nt
 
 SEM Production
-  | Production		loc       .  	ppProd 	 =  pp @con
+  | Production          loc       .     ppProd   =  pp @con
                         loc       .     prodName =  ppName [@lhs.ppNt, @loc.ppProd]
                         loc       .     conName  =  if @lhs.o_rename
                                                     then @loc.prodName
                                                     else @loc.ppProd
 SEM Child
-  | Child		loc       .  	ppCh 	 =  pp @name
+  | Child               loc       .     ppCh     =  pp @name
                         loc       .     ppTCh    =  ppShow @tp
                         loc       .     chName   =  ppName [@loc.ppCh, @lhs.ppNt, @lhs.ppProd]
 
@@ -187,13 +187,13 @@ SEM Child
 ATTR Productions Production Rules Rule Children Child Expression [ ppNt : PP_Doc | |  ]
 
 SEM Nonterminal
-  | Nonterminal         prods     .  	ppNt   	=  @loc.ppNt
+  | Nonterminal         prods     .     ppNt    =  @loc.ppNt
 
 ATTR Rules Rule Children Child Expression [ ppProd : PP_Doc | |  ]
 
 SEM Production
-  | Production          children  .  	ppProd 	=  @loc.ppProd
-		        rules     .  	ppProd 	=  @loc.ppProd
+  | Production          children  .     ppProd  =  @loc.ppProd
+                        rules     .     ppProd  =  @loc.ppProd
 
 
 ATTR Nonterminals Nonterminal [ derivs : {Derivings} | |  ]
@@ -205,7 +205,7 @@ SEM Grammar
 ATTR Nonterminals Nonterminal Production [ | | ppD USE {>-<} {empty} : {PP_Doc} ppDI USE {++} {[]} : {[PP_Doc]} ]
 
 SEM Nonterminal
-  | Nonterminal		lhs     .  	ppD    	=
+  | Nonterminal         lhs     .       ppD     =
                                      if (Set.member @nt @lhs.newNTs)
                                      then  case (lookup @nt @lhs.tSyns) of
                                                     -- if it's a data type
@@ -218,28 +218,28 @@ SEM Nonterminal
                                                     Just tp ->  "type " >|< @loc.ppNt >|< " = " >|< ppShow tp
                                      else  empty
 
-		        lhs     .  	ppDI    	=
+                        lhs     .       ppDI            =
                                      if (not $ Set.member @nt @lhs.newNTs)
                                      then  [ @loc.ppNt ]
                                      else  [ ]
 -- uncommented for testing purposes
 
 SEM Production
-  | Production		lhs     .  	ppD    	= @loc.conName >|< ppListSep " {" "}" ", " @children.ppDL
+  | Production          lhs     .       ppD     = @loc.conName >|< ppListSep " {" "}" ", " @children.ppDL
 
 
 ATTR Productions Children Child  [ | | ppDL : {[PP_Doc]} ]
 
 SEM Productions
-  | Cons			lhs		.	ppDL		=	@hd.ppD : @tl.ppDL
-  | Nil				lhs		.	ppDL		=	[]
+  | Cons                        lhs             .       ppDL            =       @hd.ppD : @tl.ppDL
+  | Nil                         lhs             .       ppDL            =       []
 
 SEM Children
-  | Cons			lhs		.	ppDL		=	@hd.ppDL ++ @tl.ppDL
-  | Nil				lhs		.	ppDL		=	[]
+  | Cons                        lhs             .       ppDL            =       @hd.ppDL ++ @tl.ppDL
+  | Nil                         lhs             .       ppDL            =       []
 
 SEM Child
-  | Child	        lhs     .  	ppDL   	= case @kind of
+  | Child               lhs     .       ppDL    = case @kind of
                                                    ChildSyntax    ->  [ @loc.chName  >|< pp " :: " >|< @loc.ppTCh ]
                                                    _              ->  []
 
@@ -261,22 +261,22 @@ ATTR Nonterminals Nonterminal Productions Production Children Child [ | | ppL US
 SEM Nonterminal
   | Nonterminal         loc     .       ntLabel = "nt_" >|< @loc.ppNt
 
-          		lhs     .  	ppL    	=  ( if (Set.member @nt @lhs.newNTs)
+                        lhs     .       ppL     =  ( if (Set.member @nt @lhs.newNTs)
                                                      then @loc.ntLabel >|< " = proxy :: Proxy " >|< @loc.ppNt
                                                      else empty)  >-<
                                                    @prods.ppL
 
-          		lhs     .  	ppLI   	=  ( if (not $ Set.member @nt @lhs.newNTs)
+                        lhs     .       ppLI    =  ( if (not $ Set.member @nt @lhs.newNTs)
                                                      then [ @loc.ntLabel ]
                                                      else [ ])  ++
                                                    @prods.ppLI
 
 SEM Production
-  | Production          lhs     .  	ppL    	=  if (Map.member @con @lhs.newProds)
+  | Production          lhs     .       ppL     =  if (Map.member @con @lhs.newProds)
                                                      then @children.ppL
                                                      else empty
 
-          		lhs     .  	ppLI   	=  if (not $ Map.member @con @lhs.newProds)
+                        lhs     .       ppLI    =  if (not $ Map.member @con @lhs.newProds)
                                                      then @children.ppLI
                                                      else []
 
@@ -284,7 +284,7 @@ SEM Production
 SEM Child
   | Child               loc     .       chLabel  = "ch_" >|< @loc.chName
                         loc     .       chTLabel = "Ch_" >|< @loc.chName
-        	        lhs     .  	ppL    	 = "data " >|< @loc.chTLabel >|< "; " >|< @loc.chLabel >|< pp " = proxy :: " >|<
+                        lhs     .       ppL      = "data " >|< @loc.chTLabel >|< "; " >|< @loc.chLabel >|< pp " = proxy :: " >|<
                                                    case @kind of
                                                     ChildSyntax    ->  "Proxy " >|< "(" >|< @loc.chTLabel >|< ", " >|< @loc.ppTCh >|< ")"
                                                     _              ->  "SemType " >|< @loc.ppTCh >|< pp " nt =>  Proxy " >|<
@@ -297,14 +297,14 @@ SEM Child
 
 
 SEM Grammar
-  | Grammar		loc     .  	ppA    	=  vlist (map defAtt (filterAtts @loc.newAtts @loc.o_noGroup)) >-<     -- not grouped
+  | Grammar             loc     .       ppA     =  vlist (map defAtt (filterAtts @loc.newAtts @loc.o_noGroup)) >-<     -- not grouped
                                                    defAtt "loc" >-<                                                    -- local
                                                    (case @lhs.ext of
                                                      Nothing    ->  defAtt "inh" >-< defAtt "syn"                      -- grouped
                                                      otherwise  ->  empty) >-<
                                                    @nonts.ppA                                                          -- record definitions
 
-        		loc     .  	ppAI   	=
+                        loc     .       ppAI    =
                                                 let atts =  filterNotAtts @loc.newAtts @loc.o_noGroup
                                                 in  (foldr (\a as -> attName a : as) [] atts) ++
                                                     (foldr (\a as -> attTName a : as) [] atts) ++
@@ -314,14 +314,14 @@ SEM Grammar
                                                     @nonts.ppAI
 
 
-        		loc     .  	ppANT 	=
+                        loc     .       ppANT   =
                                                 let atts =  filterNotAtts @loc.newAtts @loc.o_noGroup
                                                 in  (foldr (\a as -> ("nts_" >|< a) : as) [] atts)
 
 ATTR Nonterminals Nonterminal Productions Production [ | | ppA USE {>-<} {empty} : PP_Doc ]
 
 SEM Nonterminal
-  | Nonterminal		lhs     .  	ppA    	=  ( if (Set.member @nt @lhs.newNTs)
+  | Nonterminal         lhs     .       ppA     =  ( if (Set.member @nt @lhs.newNTs)
                                                      then   
                                                             defAttRec (pp "InhG") @loc.ppNt @inh @loc.inhNoGroup >-<
                                                             defAttRec (pp "SynG") @loc.ppNt @syn @loc.synNoGroup 
@@ -329,13 +329,13 @@ SEM Nonterminal
                                                    @prods.ppA
 
 SEM Production
-  | Production		lhs     .  	ppA    	=  defLocalAtts @loc.prodName (length @rules.locals) 1 $ sort @rules.locals
+  | Production          lhs     .       ppA     =  defLocalAtts @loc.prodName (length @rules.locals) 1 $ sort @rules.locals
 
 
 ATTR Nonterminals Nonterminal [ | | ppAI USE {++} {[]} : {[PP_Doc]} ]
 
 SEM Nonterminal
-  | Nonterminal		lhs     .  	ppAI    =  if (not $ Set.member @nt @lhs.newNTs)
+  | Nonterminal         lhs     .       ppAI    =  if (not $ Set.member @nt @lhs.newNTs)
                                                    then [ ppName [(pp "InhG"), @loc.ppNt ] >#< pp "(..)", ppName [(pp "SynG"), @loc.ppNt ] >#< pp "(..)" ]
                                                    else [ ]
 
@@ -372,7 +372,7 @@ ATTR Rules Rule [ | | locals USE {++} {[]} : {[Identifier]} ]
 
 
 SEM Rule
-  | Rule	        lhs     .  	locals    =  if (show (fst @pattern.info) == "loc")
+  | Rule                lhs     .       locals    =  if (show (fst @pattern.info) == "loc")
                                                       then [ snd @pattern.info ]
                                                       else [ ]
 
@@ -390,7 +390,7 @@ SEM Pattern
 
 SEM Grammar
   | Grammar             loc     .       ppNtL   =  @nonts.ppNtL
-        		loc     .  	ppR    	=  ntsList "group" @loc.ppNtL  >-<
+                        loc     .       ppR     =  ntsList "group" @loc.ppNtL  >-<
                                                    vlist (map (\att -> ntsList att (filterNts att @loc.ppNtL)) (filterAtts @newAtts @loc.o_noGroup))  >-<
                                                    @nonts.ppR
 
@@ -403,7 +403,7 @@ filterNts att = filter ( Map.member (identifier att) . snd )
 ATTR Nonterminals Nonterminal  [ | | ppNtL USE {++} {[]} : {[(PP_Doc, Attributes)]} ] -- list of nonterminals and its attributes
 
 SEM Nonterminal
-  | Nonterminal		lhs     .  	ppNtL  	=  [ ("nt_" >|< @nt, Map.union @inh @syn) ]
+  | Nonterminal         lhs     .       ppNtL   =  [ ("nt_" >|< @nt, Map.union @inh @syn) ]
 
 
 
@@ -412,7 +412,7 @@ ATTR Productions Production    [ newNT : {Bool} | |  ]
 ATTR Rules Rule    [ newProd : {Bool} | |  ]
 
 SEM Nonterminal
-  | Nonterminal		prods     .       newNT     =  Set.member @nt @lhs.newNTs
+  | Nonterminal         prods     .       newNT     =  Set.member @nt @lhs.newNTs
 
 
 ATTR Nonterminals Nonterminal Productions Production Children Child [ | | ppR USE {>-<} {empty} : PP_Doc ]
@@ -422,11 +422,11 @@ ATTR Productions Production    [ | | ppRA USE {++} {[]} : {[PP_Doc]} ]
 
 
 SEM Nonterminal
-  | Nonterminal		lhs     .       ppR     =  pp "----" >|< pp @nt >-< @prods.ppR
+  | Nonterminal         lhs     .       ppR     =  pp "----" >|< pp @nt >-< @prods.ppR
 
 SEM Production
-  | Production		loc     .       newProd  = Map.member @con @lhs.newProds
-                        loc     .  	(ppR,ppRA)
+  | Production          loc     .       newProd  = Map.member @con @lhs.newProds
+                        loc     .       (ppR,ppRA)
                            =  let  (instR, instRA)  = defInstRules  @lhs.ppNt @con @lhs.newNT @loc.newProd
                                                                     @children.ppR @rules.ppRL @children.idCL @rules.locals
                                    (locR,  locRA)   = defLocRule    @lhs.ppNt @con @lhs.newNT @loc.newProd
@@ -448,7 +448,7 @@ SEM Production
 
 
 SEM Child
-  | Child	        lhs     .  	ppR    	=  let chName = ppListSep "" "" "_" [pp @name, @lhs.ppNt, @lhs.ppProd]
+  | Child               lhs     .       ppR     =  let chName = ppListSep "" "" "_" [pp @name, @lhs.ppNt, @lhs.ppProd]
                                                    in  pp @name >|< " <- at ch_" >|< chName
 
 
@@ -465,11 +465,11 @@ ruleDef   (PPRule _      _     _     def) = def
 ATTR Rules Rule [ | | ppRL  : {[ PPRule ]} ]
 
 SEM Rules
-  | Cons			lhs		.	ppRL		=	@hd.ppRL ++ @tl.ppRL
-  | Nil				lhs		.	ppRL		=	[]
+  | Cons                        lhs             .       ppRL            =       @hd.ppRL ++ @tl.ppRL
+  | Nil                         lhs             .       ppRL            =       []
 
 SEM Rule
-  | Rule	                lhs             .  	ppRL    	=  if (not @explicit &&  not @lhs.newProd && not (Map.member (snd @pattern.info) @lhs.newAtts) )
+  | Rule                        lhs             .       ppRL            =  if (not @explicit &&  not @lhs.newProd && not (Map.member (snd @pattern.info) @lhs.newAtts) )
                                                                            then []
                                                                            else [ ppRule @pattern.info @owrt (defRule @lhs.ppNt @pattern.info @lhs.o_noGroup @rhs.ppRE) ]
 
@@ -732,11 +732,11 @@ ppMacro (Macro con children) = "( atts_" >|< show con >|< ", " >|<  ppListSep ""
 ATTR Nonterminals Nonterminal Productions Production [ | | ppCata USE {>-<} {empty} : PP_Doc ]
 
 SEM Nonterminal
-  | Nonterminal		lhs     .      ppCata    =  "----" >|< @loc.ppNt >-< @prods.ppCata
+  | Nonterminal         lhs     .      ppCata    =  "----" >|< @loc.ppNt >-< @prods.ppCata
 
 
 SEM Production
-  | Production		lhs     .      ppCata    =
+  | Production          lhs     .      ppCata    =
                                             let  extend = maybe  []
                                                                  (  \ext ->  if (@lhs.newNT || (not @lhs.newNT && @loc.newProd))
                                                                              then []
@@ -763,8 +763,8 @@ elemNT a b = False
 ATTR Productions Production [ syn, inh : { Attributes } | | ]
 
 SEM Nonterminal
-  | Nonterminal         prods     .  	syn   	=  @syn
-                        prods     .  	inh   	=  @inh
+  | Nonterminal         prods     .     syn     =  @syn
+                        prods     .     inh     =  @inh
 
 
 
@@ -775,7 +775,7 @@ ATTR Productions Production  [ | | ppSPF USE {>-<} {empty} : PP_Doc ]
 
 
 SEM Nonterminal
-  | Nonterminal  	lhs     .  	ppSF    	=
+  | Nonterminal         lhs     .       ppSF            =
                                          let      inhAtts = attTypes @loc.inhNoGroup
                                                   synAtts = attTypes @loc.synNoGroup
                                          in
@@ -800,7 +800,7 @@ attTypes atts = map (\(a,t) -> "(HCons (LVPair (Proxy Att_" >|< a >|< ") " >|< p
 
 
 SEM Production
-  | Production		lhs     .  	ppSF    	=
+  | Production          lhs     .       ppSF            =
                                             let  chi = @children.ppCSF
                                                  ppPattern = case (show @con) of
                                                               -- hardcoded list support
@@ -812,7 +812,7 @@ SEM Production
                                                  ppParams f =   f $ map (((>|<) (pp "_")) . fst) chi
                                             in   "sem_" >|< @lhs.ppNt >|< " (" >|< ppPattern >|< ") = sem_" >|< @loc.prodName >|<
                                                  " (" >|< map (fst . snd) chi >|< "emptyRecord)"
-                	lhs     .  	ppSPF    	=
+                        lhs     .       ppSPF           =
                                             let  chi = @children.ppCSF
                                                  ppParams f =   f $ map (((>|<) (pp "_")) . fst) chi
                                             in   "sem_" >|< @lhs.ppNt >|< "_" >|< @con >#< ppParams ppSpaced >|< " = semP_" >|< @loc.prodName >|<
@@ -823,7 +823,7 @@ ATTR Children Child  [ | | ppCSF USE {++} {[]} : {[(Identifier,(PP_Doc,PP_Doc))]
 
 
 SEM Child
-  | Child	        lhs     .  	ppCSF    	=
+  | Child               lhs     .       ppCSF           =
                                             let
                                                  semC   = if (isNonterminal @tp)
                                                            then "sem_" >|< ppShow @tp >|<  " _" >|< @name
@@ -843,7 +843,7 @@ SEM Child
 ATTR Nonterminals Nonterminal  [ | | ppW USE {>-<} {empty} : PP_Doc ]
 
 SEM Nonterminal
-  | Nonterminal		lhs     .  	ppW    	=
+  | Nonterminal         lhs     .       ppW     =
                                             ppName [pp "wrap", @loc.ppNt] >|< " sem " >|< attVars @inh >|< " = " >-<
                                             "   sem " >|< attFields @inh @loc.inhNoGroup @loc.ppNt
 

--- a/uuagc/trunk/src-ag/AbstractSyntaxDump.ag
+++ b/uuagc/trunk/src-ag/AbstractSyntaxDump.ag
@@ -17,7 +17,7 @@ import TokenDef
 ATTR AllPattern AllAbstractSyntax AllExpression [ | | pp USE {>-<} {empty} : PP_Doc ]
 
 SEM Grammar
-  | Grammar             lhs     .       pp      =   ppNestInfo ["Grammar","Grammar"] []
+  | Grammar         lhs     .   pp      =   ppNestInfo ["Grammar","Grammar"] []
                                                        [ ppF "typeSyns" $ ppAssocL @typeSyns
                                                        , ppF "useMap" $ ppMap $ Map.map ppMap $ @useMap
                                                        , ppF "derivings" $ ppMap $ @derivings
@@ -26,51 +26,51 @@ SEM Grammar
                                                        ] []
 
 SEM Nonterminal
-  | Nonterminal         lhs     .       pp      =   ppNestInfo ["Nonterminal","Nonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL] []
+  | Nonterminal     lhs     .   pp      =   ppNestInfo ["Nonterminal","Nonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL] []
 
 SEM Production
-  | Production          lhs     .       pp      =   ppNestInfo ["Production","Production"] [pp @con] [ppF "children" $ ppVList @children.ppL,ppF "rules" $ ppVList @rules.ppL,ppF "typeSigs" $ ppVList @typeSigs.ppL] []
+  | Production      lhs     .   pp      =   ppNestInfo ["Production","Production"] [pp @con] [ppF "children" $ ppVList @children.ppL,ppF "rules" $ ppVList @rules.ppL,ppF "typeSigs" $ ppVList @typeSigs.ppL] []
 
 SEM Child
-  | Child                       lhs     .       pp      =   ppNestInfo ["Child","Child"] [pp @name, ppShow @tp] [ppF "kind" $ ppShow @kind] []
+  | Child           lhs     .   pp      =   ppNestInfo ["Child","Child"] [pp @name, ppShow @tp] [ppF "kind" $ ppShow @kind] []
 
 SEM Rule
-  | Rule                        lhs     .       pp      =   ppNestInfo ["Rule","Rule"] [ppShow @owrt, pp @origin] [ppF "pattern" $ @pattern.pp, ppF "rhs" $ @rhs.pp] []
+  | Rule            lhs     .   pp      =   ppNestInfo ["Rule","Rule"] [ppShow @owrt, pp @origin] [ppF "pattern" $ @pattern.pp, ppF "rhs" $ @rhs.pp] []
 
 SEM TypeSig
-  | TypeSig                     lhs     .       pp      =   ppNestInfo ["TypeSig","TypeSig"] [pp @name, ppShow @tp] [] []
+  | TypeSig         lhs     .   pp      =   ppNestInfo ["TypeSig","TypeSig"] [pp @name, ppShow @tp] [] []
 
 SEM Pattern
-  | Constr                      lhs     .       pp      =   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
-  | Product                     lhs     .       pp      =   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
-  | Alias                       lhs     .       pp      =   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
-  | Underscore          lhs     .       pp      =   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
+  | Constr          lhs     .   pp      =   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
+  | Product         lhs     .   pp      =   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
+  | Alias           lhs     .   pp      =   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
+  | Underscore      lhs     .   pp      =   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
 
 SEM Expression
-  | Expression          lhs     .       pp      =   ppNestInfo ["Expression","Expression"] [ppShow @pos] [ppF "txt" $ vlist . showTokens . tokensToStrings $ @tks] []
+  | Expression      lhs     .   pp      =   ppNestInfo ["Expression","Expression"] [ppShow @pos] [ppF "txt" $ vlist . showTokens . tokensToStrings $ @tks] []
 
 ATTR Productions Nonterminals Children Rules TypeSigs Patterns [ | | ppL: {[PP_Doc]} ]
 
 SEM Patterns
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM TypeSigs
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM Rules
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM Children
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM Productions
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM Nonterminals
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []

--- a/uuagc/trunk/src-ag/AbstractSyntaxDump.ag
+++ b/uuagc/trunk/src-ag/AbstractSyntaxDump.ag
@@ -17,7 +17,7 @@ import TokenDef
 ATTR AllPattern AllAbstractSyntax AllExpression [ | | pp USE {>-<} {empty} : PP_Doc ]
 
 SEM Grammar
-  | Grammar  		lhs     .  	pp    	=   ppNestInfo ["Grammar","Grammar"] []
+  | Grammar             lhs     .       pp      =   ppNestInfo ["Grammar","Grammar"] []
                                                        [ ppF "typeSyns" $ ppAssocL @typeSyns
                                                        , ppF "useMap" $ ppMap $ Map.map ppMap $ @useMap
                                                        , ppF "derivings" $ ppMap $ @derivings
@@ -26,51 +26,51 @@ SEM Grammar
                                                        ] []
 
 SEM Nonterminal
-  | Nonterminal		lhs     .  	pp    	=   ppNestInfo ["Nonterminal","Nonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL] []
+  | Nonterminal         lhs     .       pp      =   ppNestInfo ["Nonterminal","Nonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL] []
 
 SEM Production
-  | Production		lhs     .  	pp    	=   ppNestInfo ["Production","Production"] [pp @con] [ppF "children" $ ppVList @children.ppL,ppF "rules" $ ppVList @rules.ppL,ppF "typeSigs" $ ppVList @typeSigs.ppL] []
+  | Production          lhs     .       pp      =   ppNestInfo ["Production","Production"] [pp @con] [ppF "children" $ ppVList @children.ppL,ppF "rules" $ ppVList @rules.ppL,ppF "typeSigs" $ ppVList @typeSigs.ppL] []
 
 SEM Child
-  | Child			lhs     .  	pp    	=   ppNestInfo ["Child","Child"] [pp @name, ppShow @tp] [ppF "kind" $ ppShow @kind] []
+  | Child                       lhs     .       pp      =   ppNestInfo ["Child","Child"] [pp @name, ppShow @tp] [ppF "kind" $ ppShow @kind] []
 
 SEM Rule
-  | Rule			lhs     .  	pp    	=   ppNestInfo ["Rule","Rule"] [ppShow @owrt, pp @origin] [ppF "pattern" $ @pattern.pp, ppF "rhs" $ @rhs.pp] []
+  | Rule                        lhs     .       pp      =   ppNestInfo ["Rule","Rule"] [ppShow @owrt, pp @origin] [ppF "pattern" $ @pattern.pp, ppF "rhs" $ @rhs.pp] []
 
 SEM TypeSig
-  | TypeSig			lhs     .  	pp    	=   ppNestInfo ["TypeSig","TypeSig"] [pp @name, ppShow @tp] [] []
+  | TypeSig                     lhs     .       pp      =   ppNestInfo ["TypeSig","TypeSig"] [pp @name, ppShow @tp] [] []
 
 SEM Pattern
-  | Constr			lhs     .  	pp    	=   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
-  | Product			lhs     .  	pp    	=   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
-  | Alias			lhs     .  	pp    	=   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
-  | Underscore		lhs     .  	pp    	=   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
+  | Constr                      lhs     .       pp      =   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
+  | Product                     lhs     .       pp      =   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
+  | Alias                       lhs     .       pp      =   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
+  | Underscore          lhs     .       pp      =   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
 
 SEM Expression
-  | Expression		lhs     .  	pp    	=   ppNestInfo ["Expression","Expression"] [ppShow @pos] [ppF "txt" $ vlist . showTokens . tokensToStrings $ @tks] []
+  | Expression          lhs     .       pp      =   ppNestInfo ["Expression","Expression"] [ppShow @pos] [ppF "txt" $ vlist . showTokens . tokensToStrings $ @tks] []
 
 ATTR Productions Nonterminals Children Rules TypeSigs Patterns [ | | ppL: {[PP_Doc]} ]
 
 SEM Patterns
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM TypeSigs
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM Rules
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM Children
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM Productions
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM Nonterminals
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []

--- a/uuagc/trunk/src-ag/Code.ag
+++ b/uuagc/trunk/src-ag/Code.ag
@@ -37,7 +37,7 @@ DATA Expr     | Let              decls : Decls
               | Lambda           args :  Exprs
                                  body : Expr
               | TupleExpr        exprs : Exprs
-	          | UnboxedTupleExpr exprs : Exprs
+                  | UnboxedTupleExpr exprs : Exprs
               | App              name  : {String}
                                  args  : Exprs
               | SimpleExpr       txt   : {String}
@@ -118,7 +118,7 @@ DATA Type     | Arr              left  : Type
               | TypeApp          func  : Type
                                  args  : Types
               | TupleType        tps   : Types
-	          | UnboxedTupleType tps   : Types
+                  | UnboxedTupleType tps   : Types
               | List             tp    : Type
               | SimpleType       txt   : {String}
               | NontermType      name   : String

--- a/uuagc/trunk/src-ag/Code.ag
+++ b/uuagc/trunk/src-ag/Code.ag
@@ -37,7 +37,7 @@ DATA Expr     | Let              decls : Decls
               | Lambda           args :  Exprs
                                  body : Expr
               | TupleExpr        exprs : Exprs
-                  | UnboxedTupleExpr exprs : Exprs
+              | UnboxedTupleExpr exprs : Exprs
               | App              name  : {String}
                                  args  : Exprs
               | SimpleExpr       txt   : {String}
@@ -118,7 +118,7 @@ DATA Type     | Arr              left  : Type
               | TypeApp          func  : Type
                                  args  : Types
               | TupleType        tps   : Types
-                  | UnboxedTupleType tps   : Types
+              | UnboxedTupleType tps   : Types
               | List             tp    : Type
               | SimpleType       txt   : {String}
               | NontermType      name   : String

--- a/uuagc/trunk/src-ag/CodeSyntaxDump.ag
+++ b/uuagc/trunk/src-ag/CodeSyntaxDump.ag
@@ -51,7 +51,7 @@ SEM CGrammar
                                                        ] []
 
 SEM CNonterminal
-  | CNonterminal                lhs     .       pp      =   ppNestInfo ["CNonterminal","CNonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL, ppF "inter" @inter.pp] []
+  | CNonterminal        lhs     .   pp      =   ppNestInfo ["CNonterminal","CNonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL, ppF "inter" @inter.pp] []
 
 SEM CInterface
   | CInterface      lhs     .   pp      =   ppNestInfo ["CInterface","CInterface"] [] [ppF "seg" $ ppVList @seg.ppL] []
@@ -60,44 +60,44 @@ SEM CSegment
   | CSegment        lhs     .   pp      =   ppNestInfo ["CSegment","CSegment"] [] [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn] []
 
 SEM CProduction
-  | CProduction lhs     .       pp      =   ppNestInfo ["CProduction","CProduction"] [pp @con] [ppF "visits" $ ppVList @visits.ppL, ppF "children" $ ppVList (map ppChild @children),ppF "terminals" $ ppVList (map ppShow @terminals)] []
+  | CProduction lhs     .   pp      =   ppNestInfo ["CProduction","CProduction"] [pp @con] [ppF "visits" $ ppVList @visits.ppL, ppF "children" $ ppVList (map ppChild @children),ppF "terminals" $ ppVList (map ppShow @terminals)] []
 
 SEM CVisit
   | CVisit          lhs     .   pp      =   ppNestInfo ["CVisit","CVisit"] [] [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "sequence" $ ppVList @vss.ppL, ppF "intra" $ ppVList @intra.ppL, ppF "ordered" $ ppBool @ordered] []
 
 SEM CRule
-  | CRule                       lhs     .       pp      =   ppNestInfo ["CRule","CRule"] [pp @name] [ppF "isIn" $ ppBool @isIn, ppF "hasCode" $ ppBool @hasCode, ppF "nt" $ pp @nt, ppF "con" $ pp @con, ppF "field" $ pp @field, ppF "childnt" $ ppMaybeShow @childnt, ppF "tp" $ ppMaybeShow @tp, ppF "pattern" $ if @isIn then pp "<no pat because In>" else @pattern.pp, ppF "rhs" $ ppStrings @rhs, ppF "defines" $ ppVertexMap @defines, ppF "owrt" $ ppBool @owrt, ppF "origin" $ pp @origin] []
+  | CRule           lhs     .   pp      =   ppNestInfo ["CRule","CRule"] [pp @name] [ppF "isIn" $ ppBool @isIn, ppF "hasCode" $ ppBool @hasCode, ppF "nt" $ pp @nt, ppF "con" $ pp @con, ppF "field" $ pp @field, ppF "childnt" $ ppMaybeShow @childnt, ppF "tp" $ ppMaybeShow @tp, ppF "pattern" $ if @isIn then pp "<no pat because In>" else @pattern.pp, ppF "rhs" $ ppStrings @rhs, ppF "defines" $ ppVertexMap @defines, ppF "owrt" $ ppBool @owrt, ppF "origin" $ pp @origin] []
   | CChildVisit     lhs     .   pp      =   ppNestInfo ["CRule","CChildVisit"] [pp @name] [ppF "nt" $ pp @nt, ppF "nr" $ ppShow @nr, ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "last" $ ppBool @isLast] []
 
 SEM Pattern
-  | Constr                      lhs     .       pp      =   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
-  | Product                     lhs     .       pp      =   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
-  | Alias                       lhs     .       pp      =   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
-  | Underscore          lhs     .       pp      =   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
+  | Constr          lhs     .   pp      =   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
+  | Product         lhs     .   pp      =   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
+  | Alias           lhs     .   pp      =   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
+  | Underscore      lhs     .   pp      =   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
 
 
 ATTR CNonterminals CSegments CProductions CVisits Sequence Patterns [ | | ppL: {[PP_Doc]} ]
 
 SEM Patterns
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM Sequence
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM CVisits
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM CProductions
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM CSegments
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []
 
 SEM CNonterminals
-  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
-  | Nil                         lhs             .       ppL             =       []
+  | Cons            lhs     .   ppL     =   @hd.pp : @tl.ppL
+  | Nil             lhs     .   ppL     =   []

--- a/uuagc/trunk/src-ag/CodeSyntaxDump.ag
+++ b/uuagc/trunk/src-ag/CodeSyntaxDump.ag
@@ -44,14 +44,14 @@ ppStrings = vlist
 ATTR AllPattern AllCodeSyntax [ | | pp USE {>-<} {empty} : PP_Doc ]
 
 SEM CGrammar
-  | CGrammar        lhs     .  	pp    	=   ppNestInfo ["CGrammar","CGrammar"] []
+  | CGrammar        lhs     .   pp      =   ppNestInfo ["CGrammar","CGrammar"] []
                                                        [ ppF "typeSyns"  $ ppAssocL @typeSyns
                                                        , ppF "derivings" $ ppMap $ @derivings
                                                        , ppF "nonts"     $ ppVList @nonts.ppL
                                                        ] []
 
 SEM CNonterminal
-  | CNonterminal		lhs     .  	pp    	=   ppNestInfo ["CNonterminal","CNonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL, ppF "inter" @inter.pp] []
+  | CNonterminal                lhs     .       pp      =   ppNestInfo ["CNonterminal","CNonterminal"] (pp @nt : map pp @params) [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "prods" $ ppVList @prods.ppL, ppF "inter" @inter.pp] []
 
 SEM CInterface
   | CInterface      lhs     .   pp      =   ppNestInfo ["CInterface","CInterface"] [] [ppF "seg" $ ppVList @seg.ppL] []
@@ -60,44 +60,44 @@ SEM CSegment
   | CSegment        lhs     .   pp      =   ppNestInfo ["CSegment","CSegment"] [] [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn] []
 
 SEM CProduction
-  | CProduction	lhs     .  	pp    	=   ppNestInfo ["CProduction","CProduction"] [pp @con] [ppF "visits" $ ppVList @visits.ppL, ppF "children" $ ppVList (map ppChild @children),ppF "terminals" $ ppVList (map ppShow @terminals)] []
+  | CProduction lhs     .       pp      =   ppNestInfo ["CProduction","CProduction"] [pp @con] [ppF "visits" $ ppVList @visits.ppL, ppF "children" $ ppVList (map ppChild @children),ppF "terminals" $ ppVList (map ppShow @terminals)] []
 
 SEM CVisit
   | CVisit          lhs     .   pp      =   ppNestInfo ["CVisit","CVisit"] [] [ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "sequence" $ ppVList @vss.ppL, ppF "intra" $ ppVList @intra.ppL, ppF "ordered" $ ppBool @ordered] []
 
 SEM CRule
-  | CRule			lhs     .  	pp    	=   ppNestInfo ["CRule","CRule"] [pp @name] [ppF "isIn" $ ppBool @isIn, ppF "hasCode" $ ppBool @hasCode, ppF "nt" $ pp @nt, ppF "con" $ pp @con, ppF "field" $ pp @field, ppF "childnt" $ ppMaybeShow @childnt, ppF "tp" $ ppMaybeShow @tp, ppF "pattern" $ if @isIn then pp "<no pat because In>" else @pattern.pp, ppF "rhs" $ ppStrings @rhs, ppF "defines" $ ppVertexMap @defines, ppF "owrt" $ ppBool @owrt, ppF "origin" $ pp @origin] []
+  | CRule                       lhs     .       pp      =   ppNestInfo ["CRule","CRule"] [pp @name] [ppF "isIn" $ ppBool @isIn, ppF "hasCode" $ ppBool @hasCode, ppF "nt" $ pp @nt, ppF "con" $ pp @con, ppF "field" $ pp @field, ppF "childnt" $ ppMaybeShow @childnt, ppF "tp" $ ppMaybeShow @tp, ppF "pattern" $ if @isIn then pp "<no pat because In>" else @pattern.pp, ppF "rhs" $ ppStrings @rhs, ppF "defines" $ ppVertexMap @defines, ppF "owrt" $ ppBool @owrt, ppF "origin" $ pp @origin] []
   | CChildVisit     lhs     .   pp      =   ppNestInfo ["CRule","CChildVisit"] [pp @name] [ppF "nt" $ pp @nt, ppF "nr" $ ppShow @nr, ppF "inh" $ ppMap @inh, ppF "syn" $ ppMap @syn, ppF "last" $ ppBool @isLast] []
 
 SEM Pattern
-  | Constr			lhs     .  	pp    	=   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
-  | Product			lhs     .  	pp    	=   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
-  | Alias			lhs     .  	pp    	=   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
-  | Underscore		lhs     .  	pp    	=   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
+  | Constr                      lhs     .       pp      =   ppNestInfo ["Pattern","Constr"] [pp @name] [ppF "pats" $ ppVList @pats.ppL] []
+  | Product                     lhs     .       pp      =   ppNestInfo ["Pattern","Product"] [ppShow @pos] [ppF "pats" $ ppVList @pats.ppL] []
+  | Alias                       lhs     .       pp      =   ppNestInfo ["Pattern","Alias"] [pp @field, pp @attr] [ppF "pat" $ @pat.pp] []
+  | Underscore          lhs     .       pp      =   ppNestInfo ["Pattern","Underscore"] [ppShow @pos] [] []
 
 
 ATTR CNonterminals CSegments CProductions CVisits Sequence Patterns [ | | ppL: {[PP_Doc]} ]
 
 SEM Patterns
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM Sequence
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM CVisits
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM CProductions
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM CSegments
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []
 
 SEM CNonterminals
-  | Cons			lhs		.	ppL		=	@hd.pp : @tl.ppL
-  | Nil				lhs		.	ppL		=	[]
+  | Cons                        lhs             .       ppL             =       @hd.pp : @tl.ppL
+  | Nil                         lhs             .       ppL             =       []

--- a/uuagc/trunk/src-ag/DefaultRules.ag
+++ b/uuagc/trunk/src-ag/DefaultRules.ag
@@ -315,7 +315,7 @@ useRule opts locals ch_outs (n,(op,e,pos))
           | isSpace c = isOp cs
           | isAlpha c = case dropWhile isAlpha cs of
                        ('.':cs2) -> isOp cs2 -- fully qualified name, drop prefix
-               _         -> False
+                       _         -> False
           | c == '('  = False
           | otherwise = True
 

--- a/uuagc/trunk/src-ag/DistChildAttr.ag
+++ b/uuagc/trunk/src-ag/DistChildAttr.ag
@@ -5,7 +5,7 @@ ATTR Nonterminals Nonterminal [ || inhMap', synMap' USE {`Map.union`} {Map.empty
 
 SEM Nonterminal
   | Nonterminal  lhs.inhMap' = Map.singleton @nt @inh
-    		 lhs.synMap' = Map.singleton @nt @syn
+                 lhs.synMap' = Map.singleton @nt @syn
 
 ATTR Nonterminals Nonterminal
      Productions Production
@@ -13,12 +13,12 @@ ATTR Nonterminals Nonterminal
 
 SEM Grammar
   | Grammar nonts.inhMap = @nonts.inhMap'
-    	    nonts.synMap = @nonts.synMap'
+            nonts.synMap = @nonts.synMap'
 
 SEM Child
   | Child loc.chnt = case @tp of
                        NT nt _ _ -> nt
                        Self      -> error ("The type of child " ++ show @name ++ " should not be a Self type.")
                        Haskell t -> identifier "" -- should be ignored because the child is a terminal
-	  loc.inh = Map.findWithDefault Map.empty @loc.chnt @lhs.inhMap
-    	  loc.syn = Map.findWithDefault Map.empty @loc.chnt @lhs.synMap
+          loc.inh = Map.findWithDefault Map.empty @loc.chnt @lhs.inhMap
+          loc.syn = Map.findWithDefault Map.empty @loc.chnt @lhs.synMap

--- a/uuagc/trunk/src-ag/ExecutionPlan2Caml.ag
+++ b/uuagc/trunk/src-ag/ExecutionPlan2Caml.ag
@@ -242,7 +242,7 @@ SEM ENonterminal | ENonterminal
 
   loc.moduleDecl
     = let ppModule :: PP a => a -> PP_Doc
-      	  ppModule expr = "module" >#< modName @nt >#< "="
+          ppModule expr = "module" >#< modName @nt >#< "="
       in case lookup @nt @lhs.typeSyns of
            Just (Map k _)  -> ppModule ("Map.Make" >#< pp_parens (ppTp k))
            Just (IntMap _) -> ppModule ("Map.Make ()")
@@ -323,7 +323,7 @@ SEM ENonterminal | ENonterminal
   loc.o_sigs  = typeSigs @lhs.options
   loc.sem_nt_body = "match arg with" >-< (indent 2 $ @prods.sem_nt)
   loc.sem_nt  = let genSem :: PP a => a -> PP_Doc -> PP_Doc
-  	      	    genSem nm body = "and" >#< ppFunDecl @loc.o_sigs (pp @loc.semname) [(pp nm, @loc.sem_param_tp)] @loc.sem_res_tp body
+                    genSem nm body = "and" >#< ppFunDecl @loc.o_sigs (pp @loc.semname) [(pp nm, @loc.sem_param_tp)] @loc.sem_res_tp body
                     genAlias alts = genSem (pp "arg") (pp "match arg with" >-< (indent 2 $ vlist $ map (pp "|" >#<) alts))
                     genMap v = let body = modName @nt >|< ".fold" >#< @loc.semname >|< "_Entry" >#< @loc.semname >|< "_Nil" >#< els
                                    els  = case v of
@@ -1087,12 +1087,12 @@ SEM Pattern | Alias
 ATTR Pattern Patterns  [ | | attrTypes USE {>-<} {empty} : {PP_Doc} ]
 SEM Pattern | Alias
   loc.mbTp      = if @field == _LHS
-  		  then Map.lookup @attr @lhs.synmap
-		  else if @field == _LOC
-		       then Map.lookup @attr @lhs.localAttrTypes
-		       else Nothing
+                  then Map.lookup @attr @lhs.synmap
+                  else if @field == _LOC
+                       then Map.lookup @attr @lhs.localAttrTypes
+                       else Nothing
   lhs.attrTypes = maybe empty (\tp -> (attrname @lhs.options False @field @attr) >#< "::" >#< ppTp tp) @loc.mbTp
-  		  >-< @pat.attrTypes
+                  >-< @pat.attrTypes
 
 -- Collect the attributes used by the right-hand side
 ATTR HsToken Expression [ | | attrs USE {`Map.union`} {Map.empty} : {Map String (Maybe NonLocalAttr)} ]

--- a/uuagc/trunk/src-ag/ExecutionPlan2Clean.ag
+++ b/uuagc/trunk/src-ag/ExecutionPlan2Clean.ag
@@ -658,16 +658,16 @@ ppDefor (Haskell s)    = text s
 SEM EProduction
   | EProduction loc.t_type   = "T_" >|< @lhs.nt
                 loc.t_params = ppSpaced @lhs.params
-		loc.usedArgs = @children.usedArgs `Set.union` @visits.usedArgs `Set.union` @rules.usedArgs
-		-- A bit ugly, but this code renames arguments and puts an underscore when the argument
-		-- is never used. This avoids compiler warnings of unused variables.
+                loc.usedArgs = @children.usedArgs `Set.union` @visits.usedArgs `Set.union` @rules.usedArgs
+                -- A bit ugly, but this code renames arguments and puts an underscore when the argument
+                -- is never used. This avoids compiler warnings of unused variables.
                 loc.args     = map (\x -> let (name,arg) = case show x of 
-					               ""       -> ("", empty)
-				       		       '!':name -> ("arg_" ++ name, "!arg_" >|< name)
-						       name     -> ("arg_" ++ name, "arg_"  >|< name)
+                                                       ""       -> ("", empty)
+                                                       '!':name -> ("arg_" ++ name, "!arg_" >|< name)
+                                                       name     -> ("arg_" ++ name, "arg_"  >|< name)
                                           in  if null name || name `Set.member` @loc.usedArgs
-			       	       	                    then arg
-			       	       	                    else text "_") @children.argpats
+                                                            then arg
+                                                            else text "_") @children.argpats
                 loc.semname  = "sem_" ++ show @lhs.nt ++ "_" ++ show @con
                 loc.sem_tp   = @loc.quantPP2 >#< @loc.classPP2 >#< ppSpaced @children.argtps
                                >#< (if length @children.argtps > 0 then "->" else "")
@@ -898,8 +898,8 @@ SEM ERule
 
 SEM EChild
   | EChild +usedArgs = \s -> case @kind of
-    	   		     ChildSyntax -> Set.insert ("arg_" ++ show @name ++ "_") s
-			     _           -> s
+                             ChildSyntax -> Set.insert ("arg_" ++ show @name ++ "_") s
+                             _           -> s
 
 
 -- Number of steps in a 'Sim' block
@@ -1152,13 +1152,13 @@ SEM Pattern | Alias
 ATTR Pattern Patterns  [ | | attrTypes USE {>-<} {empty} : {PP_Doc} ]
 SEM Pattern | Alias
   loc.mbTp      = if @field == _LHS
-  		  then Map.lookup @attr @lhs.synmap
-		  else if @field == _LOC
-		       then Map.lookup @attr @lhs.localAttrTypes
-		       else Nothing
+                  then Map.lookup @attr @lhs.synmap
+                  else if @field == _LOC
+                       then Map.lookup @attr @lhs.localAttrTypes
+                       else Nothing
   lhs.attrTypes = empty -- Don't generate these type signatures; increases performance in Clean
                   -- maybe empty (\tp -> (attrname @lhs.options False @field @attr) >#< "::" >#< ppTp tp) @loc.mbTp
-  		            -- >-< @pat.attrTypes
+                            -- >-< @pat.attrTypes
 
 -- Collect the attributes used by the right-hand side
 ATTR HsToken Expression [ | | attrs USE {`Map.union`} {Map.empty} : {Map String (Maybe NonLocalAttr)} ]

--- a/uuagc/trunk/src-ag/ExecutionPlan2Hs.ag
+++ b/uuagc/trunk/src-ag/ExecutionPlan2Hs.ag
@@ -595,16 +595,16 @@ ppDefor (Haskell s)    = text s
 SEM EProduction
   | EProduction loc.t_type   = "T_" >|< @lhs.nt
                 loc.t_params = ppSpaced @lhs.params
-		loc.usedArgs = @children.usedArgs `Set.union` @visits.usedArgs `Set.union` @rules.usedArgs
-		-- A bit ugly, but this code renames arguments and puts an underscore when the argument
-		-- is never used. This avoids compiler warnings of unused variables.
+                loc.usedArgs = @children.usedArgs `Set.union` @visits.usedArgs `Set.union` @rules.usedArgs
+                -- A bit ugly, but this code renames arguments and puts an underscore when the argument
+                -- is never used. This avoids compiler warnings of unused variables.
                 loc.args     = map (\x -> let (name,arg) = case show x of 
-					               ""       -> ("", empty)
-				       		       '!':name -> ("arg_" ++ name, "!arg_" >|< name)
-						       name     -> ("arg_" ++ name, "arg_"  >|< name)
+                                                       ""       -> ("", empty)
+                                                       '!':name -> ("arg_" ++ name, "!arg_" >|< name)
+                                                       name     -> ("arg_" ++ name, "arg_"  >|< name)
                                           in  if null name || name `Set.member` @loc.usedArgs
-			       	       	      then arg
-			       	       	      else text "_") @children.argpats
+                                              then arg
+                                              else text "_") @children.argpats
                 loc.semname  = "sem_" ++ show @lhs.nt ++ "_" ++ show @con
                 loc.sem_tp   = @loc.quantPP2 >#< @loc.classPP2 >#< ppSpaced @children.argtps >#< @loc.t_type >#< @loc.t_params
                 loc.classPP2 = ppClasses (classCtxsToDocs @lhs.classCtxs ++ classConstrsToDocs @constraints)
@@ -870,8 +870,8 @@ SEM ERule
 
 SEM EChild
   | EChild +usedArgs = \s -> case @kind of
-    	   		     ChildSyntax -> Set.insert ("arg_" ++ show @name ++ "_") s
-			     _           -> s
+                             ChildSyntax -> Set.insert ("arg_" ++ show @name ++ "_") s
+                             _           -> s
 
 
 -- Number of steps in a 'Sim' block
@@ -1061,17 +1061,17 @@ SEM ERule | ERule
                                   | (str,mbAttr) <- Map.assocs @rhs.attrs
                                   ]
       loc.argExprs     = ppSpaced [ case mbAttr of
-      		       	 	       Nothing -> "arg_" >|< str
-				       _       -> text str
+                                       Nothing -> "arg_" >|< str
+                                       _       -> text str
                                   | (str,mbAttr) <- Map.assocs @rhs.attrs
                                   ]
       loc.stepcode     = \kind fmtMode -> if kind `compatibleRule` @pure
                                           then Right $ let oper | @pure     = "="
                                                                 | otherwise = "<-"
                                                            decl = @pattern.sem_lhs >#< oper >#< @name >#< @loc.argExprs >#< dummyArg @lhs.options (Map.null @rhs.attrs)
-							   tp   = if @pure && not (noPerRuleTypeSigs @lhs.options)
-							   	  then @pattern.attrTypes
-								  else empty
+                                                           tp   = if @pure && not (noPerRuleTypeSigs @lhs.options)
+                                                                  then @pattern.attrTypes
+                                                                  else empty
                                                        in fmtDecl @pure fmtMode (tp >-< decl)
                                           else Left $ IncompatibleRuleKind @name kind
 
@@ -1157,12 +1157,12 @@ SEM Pattern | Alias
 ATTR Pattern Patterns  [ | | attrTypes USE {>-<} {empty} : {PP_Doc} ]
 SEM Pattern | Alias
   loc.mbTp      = if @field == _LHS
-  		  then Map.lookup @attr @lhs.synmap
-		  else if @field == _LOC
-		       then Map.lookup @attr @lhs.localAttrTypes
-		       else Nothing
+                  then Map.lookup @attr @lhs.synmap
+                  else if @field == _LOC
+                       then Map.lookup @attr @lhs.localAttrTypes
+                       else Nothing
   lhs.attrTypes = maybe empty (\tp -> (attrname @lhs.options False @field @attr) >#< "::" >#< ppTp tp) @loc.mbTp
-  		  >-< @pat.attrTypes
+                  >-< @pat.attrTypes
 
 -- Collect the attributes used by the right-hand side
 ATTR HsToken Expression [ | | attrs USE {`Map.union`} {Map.empty} : {Map String (Maybe NonLocalAttr)} ]
@@ -1468,7 +1468,7 @@ SEM ExecutionPlan
                   loc.commonFile      = replaceBaseName @lhs.mainFile (takeBaseName @lhs.mainFile ++ "_common")
                   loc.genCommonModule = writeModule @loc.commonFile
                                           ( [ pp $ "{-# LANGUAGE Rank2Types, GADTs #-}"  -- the common module only needs GADTs and Rank2Types
-					    , pp $ @lhs.pragmaBlocks
+                                            , pp $ @lhs.pragmaBlocks
                                             , pp $ @lhs.moduleHeader @lhs.mainName "_common" "" True
                                             , @loc.ppMonadImports
                                             , @lhs.importBlocks

--- a/uuagc/trunk/src-ag/ExecutionPlanCommon.ag
+++ b/uuagc/trunk/src-ag/ExecutionPlanCommon.ag
@@ -141,13 +141,13 @@ SEM Child
 -------------------------------------------------------------------------------
 ATTR Grammar
      Nonterminals  [ | | inhmap USE {`Map.union`} {Map.empty} : {Map.Map NontermIdent Attributes}
-     	                 synmap USE {`Map.union`} {Map.empty} : {Map.Map NontermIdent Attributes} ]
+                         synmap USE {`Map.union`} {Map.empty} : {Map.Map NontermIdent Attributes} ]
 
 ATTR Nonterminal [ | | inhmap : {Map.Map NontermIdent Attributes}
-     		       synmap : {Map.Map NontermIdent Attributes} ]
+                       synmap : {Map.Map NontermIdent Attributes} ]
 SEM Nonterminal
   | Nonterminal lhs.inhmap = Map.singleton @nt @inh
-    		lhs.synmap = Map.singleton @nt @syn
+                lhs.synmap = Map.singleton @nt @syn
 
 -------------------------------------------------------------------------------
 --         Output nonterminal type mappings

--- a/uuagc/trunk/src-ag/ExecutionPlanPre.ag
+++ b/uuagc/trunk/src-ag/ExecutionPlanPre.ag
@@ -10,6 +10,6 @@ SEM  Grammar
 
 SEM  Rule
   |  Rule lhs.rulenumber = @lhs.rulenumber + 1
-     	  loc.rulename   = maybe (identifier $ "rule" ++ show @lhs.rulenumber) id @mbName
+          loc.rulename   = maybe (identifier $ "rule" ++ show @lhs.rulenumber) id @mbName
 
 

--- a/uuagc/trunk/src-ag/GenerateCode.ag
+++ b/uuagc/trunk/src-ag/GenerateCode.ag
@@ -514,7 +514,7 @@ SEM  CVisit
             loc.semType = let argType (NT tp tps _)  r | tp /= _SELF = typeAppStrs (sdtype tp) tps `Arr` r
                                                        | tp == _SELF = error "GenerateCode: found an intra-type with type SELF, which should have been prevented by CRule.tps"
                               argType (Haskell tp) r                 = SimpleType tp          `Arr` r
-                  argType _ _ = error "Self type not allowed here"
+                              argType _ _ = error "Self type not allowed here"
                               evalTp | null @loc.params = id
                                      | otherwise        = idEvalType @lhs.options
 
@@ -918,9 +918,9 @@ SEM CRule
 makeLocalComment :: Int -> String -> Identifier -> Maybe Type -> String
 makeLocalComment width what  name tp = let  x = getName name
                                             y = maybe "_" (\t -> case t of
-                                  (NT nt tps _) -> getName nt ++ " " ++ unwords tps
-                                  Haskell t' -> '{' : t' ++ "}"
-                              Self -> error "Self type not allowed here.") tp
+                                                                   (NT nt tps _) -> getName nt ++ " " ++ unwords tps
+                                                                   Haskell t' -> '{' : t' ++ "}"
+                                                                   Self -> error "Self type not allowed here.") tp
                                        in   ( what ++ " " ++ x ++ replicate ((width - length x) `max` 0) ' ' ++ " : " ++ y )
 
 }
@@ -1033,7 +1033,7 @@ SEM CProductions
 SEM CProduction
   | CProduction loc.params  = map getName $ Map.findWithDefault [] @lhs.nt @lhs.paramMap
                 lhs.dataAlt = let conNm = conname @lhs.o_rename @lhs.nt @con
-                      mkFields :: (NontermIdent -> ConstructorIdent -> Identifier -> Code.Type -> a) -> [a]
+                                  mkFields :: (NontermIdent -> ConstructorIdent -> Identifier -> Code.Type -> a) -> [a]
                                   mkFields f = map (\(nm,t,_) -> f @lhs.nt @con nm (typeToCodeType (Just @lhs.nt) @loc.params $ removeDeforested t)) @loc.firstOrderChildren
                               in if dataRecords @lhs.options
                                  then Record conNm $ mkFields $ toNamedType (strictData @lhs.options)

--- a/uuagc/trunk/src-ag/InterfacesRules.lag
+++ b/uuagc/trunk/src-ag/InterfacesRules.lag
@@ -408,7 +408,7 @@ SEM  Segment [ | | seg : CSegment
               loc.inhmap : {Map Identifier Type}
               loc.synmap : {Map Identifier Type}
               loc.(inhmap,synmap) = let makemap = Map.fromList . map findType
-					findType v = getNtaNameType (attrTable @lhs.info ! v)
+                                        findType v = getNtaNameType (attrTable @lhs.info ! v)
                                     in (makemap @inh,makemap @syn)
               lhs.cvisits = let  mkVisit vss intra = CVisit @inhmap @synmap (mkSequence vss) (mkSequence intra) True
                                  mkSequence = map mkRule

--- a/uuagc/trunk/src-ag/KWOrder.ag
+++ b/uuagc/trunk/src-ag/KWOrder.ag
@@ -42,37 +42,37 @@ ATTR HsToken Expression
 SEM  HsToken
   |  AGLocal lhs.vertices = Set.singleton $ VChild @var
   |  AGField lhs.vertices = Set.singleton $ VAttr (if      @field == _LHS then Inh
-     	     		    		    	   else if @field == _LOC then Loc
-						   else    	     	       Syn) @field @attr
+                                                   else if @field == _LOC then Loc
+                                                   else                        Syn) @field @attr
 
 -- Gather vertices for an expression (make a higher order child)
 SEM  Expression
   |  Expression lhs.vertices = Set.unions $ map (\tok -> vertices_Syn_HsToken
-     			       		    (wrap_HsToken (sem_HsToken tok) Inh_HsToken)) @tks
+                                            (wrap_HsToken (sem_HsToken tok) Inh_HsToken)) @tks
 
 -- Gather vertices at patterns
 SEM  Pattern
-  |  Alias loc.vertex   = if		      @field == _INST then VChild @attr
-     	   		  else VAttr (if      @field == _LHS  then Syn
-     	     		    	      else if @field == _LOC  then Loc
-				      else 	 	      	   Inh) @field @attr
-     	   lhs.vertices = Set.insert @loc.vertex @pat.vertices
+  |  Alias loc.vertex   = if                  @field == _INST then VChild @attr
+                          else VAttr (if      @field == _LHS  then Syn
+                                      else if @field == _LOC  then Loc
+                                      else                         Inh) @field @attr
+           lhs.vertices = Set.insert @loc.vertex @pat.vertices
 
 -- Gather vertices for children
 --
 -- The behavior for merged children is a bit more complicated (and ignored for now)
 SEM  Child
   |  Child loc.vertex      = VChild @name
-     	   loc.synvertices = map (VAttr Syn @name) . Map.keys $ @loc.syn
-     	   loc.inhvertices = map (VAttr Inh @name) . Map.keys $ @loc.inh
-	   lhs.vertices    = case @tp of -- only Nonterminal children need to be in dependency graph
-     	   		        NT _ _ _ -> Set.insert @loc.vertex $ Set.fromList (@loc.synvertices ++ @loc.inhvertices)
-			     	_        -> Set.empty
+           loc.synvertices = map (VAttr Syn @name) . Map.keys $ @loc.syn
+           loc.inhvertices = map (VAttr Inh @name) . Map.keys $ @loc.inh
+           lhs.vertices    = case @tp of -- only Nonterminal children need to be in dependency graph
+                                NT _ _ _ -> Set.insert @loc.vertex $ Set.fromList (@loc.synvertices ++ @loc.inhvertices)
+                                _        -> Set.empty
 
 -- Add extra vertex for a rule
 SEM  Rule
   |  Rule loc.vertex   = VRule @loc.rulename
-     	  lhs.vertices = Set.insert @loc.vertex $ @pattern.vertices `Set.union` @rhs.vertices
+          lhs.vertices = Set.insert @loc.vertex $ @pattern.vertices `Set.union` @rhs.vertices
 
 -- Combine all vertices for a production
 SEM  Production
@@ -85,8 +85,8 @@ ATTR Rule Rules
 -- Gather edges for a rule
 SEM  Rule
   |  Rule loc.edgesout = map ((,) @loc.vertex) (Set.toList @rhs.vertices)
-     	  loc.edgesin  = map (flip (,) @loc.vertex) (Set.toList @pattern.vertices)
-	  lhs.edges    = Set.fromList $ @loc.edgesout ++ @loc.edgesin
+          loc.edgesin  = map (flip (,) @loc.vertex) (Set.toList @pattern.vertices)
+          lhs.edges    = Set.fromList $ @loc.edgesout ++ @loc.edgesin
 
 -- When a child is defined by a higher order attribute and the late binding option
 -- is enabled, we refer to the additional inherited attribute under the hood, hence
@@ -109,8 +109,8 @@ SEM Child | Child
 -- Gather edges for a child
 SEM  Child
   |  Child loc.edgesout = @loc.higherOrderEdges
-     	   loc.edgesin  = map (flip (,) @loc.vertex) @loc.synvertices
-	   lhs.edges    = Set.fromList (@loc.edgesout ++ @loc.edgesin)
+           loc.edgesin  = map (flip (,) @loc.vertex) @loc.synvertices
+           lhs.edges    = Set.fromList (@loc.edgesout ++ @loc.edgesin)
 
 -- Add manual attribute dependencies
 ATTR Nonterminals Nonterminal [ manualDeps : AttrOrderMap | | ]
@@ -149,8 +149,8 @@ ATTR Child Children [ | | nontnames USE {++} {[]} : {[(Identifier, Identifier)]}
 
 SEM  Child
   |  Child lhs.nontnames = case @tp of
-     	   		     NT nont _ _ -> [(@name, nont)]
-			     _           -> []
+                             NT nont _ _ -> [(@name, nont)]
+                             _           -> []
 
 -- Return a dependency graph for each production
 ATTR Production  [ | | depgraph : {ProdDependencyGraph} ]
@@ -158,13 +158,13 @@ ATTR Productions [ | | depgraph USE {:} {[]} : {[ProdDependencyGraph]} ]
 
 SEM  Production
   |  Production lhs.depgraph  = ProdDependencyGraph { pdgVertices    = Set.toList @loc.vertices
-			      			    , pdgEdges       = Set.toList @loc.edges
-						    , pdgRules       = @rules.erules
-						    , pdgChilds      = @children.echilds
-						    , pdgProduction  = @con
-                                               	    , pdgChildMap    = @children.nontnames
-                                               	    , pdgConstraints = @constraints
-                                               	    , pdgParams      = @params }
+                                                    , pdgEdges       = Set.toList @loc.edges
+                                                    , pdgRules       = @rules.erules
+                                                    , pdgChilds      = @children.echilds
+                                                    , pdgProduction  = @con
+                                                    , pdgChildMap    = @children.nontnames
+                                                    , pdgConstraints = @constraints
+                                                    , pdgParams      = @params }
 
 -------------------------------------------------------------------------------
 --         Dependency graph per nonterminal
@@ -173,13 +173,13 @@ SEM  Production
 -- Vertices are just all inherited and syntesized attributes
 SEM  Nonterminal
   |  Nonterminal loc.synvertices = map (VAttr Syn @nt) . Map.keys $ @syn
-     	   	 loc.inhvertices = map (VAttr Inh @nt) . Map.keys $ @inh
-	   	 loc.vertices    = @loc.synvertices ++ @loc.inhvertices
+                 loc.inhvertices = map (VAttr Inh @nt) . Map.keys $ @inh
+                 loc.vertices    = @loc.synvertices ++ @loc.inhvertices
 
 -- Construct nonterminal dependency graph for production
 SEM  Nonterminal
   |  Nonterminal loc.nontgraph = NontDependencyGraph { ndgVertices = @loc.vertices
-     		 	       	 		     , ndgEdges    = [] }
+                                                     , ndgEdges    = [] }
 
 -- Create dependency information for nonterminal and pass it upwards
 ATTR Nonterminal  [ | | depinfo : {NontDependencyInformation} ]
@@ -187,7 +187,7 @@ ATTR Nonterminals [ | | depinfo USE {:} {[]} : {[NontDependencyInformation]} ]
 
 SEM  Nonterminal
   |  Nonterminal lhs.depinfo = NontDependencyInformation { ndiNonterminal = @nt
-     		 	       				 , ndiParams      = @params
+                                                         , ndiParams      = @params
                                                          , ndiInh         = Map.keys @inh
                                                          , ndiSyn         = Map.keys @syn
                                                          , ndiDepGraph    = @loc.nontgraph
@@ -201,9 +201,9 @@ SEM  Nonterminal
 --         Call the kennedy-warren algorithm
 -------------------------------------------------------------------------------
 ATTR Grammar [ | | output : {ExecutionPlan}
-     	       	   depgraphs : {PP_Doc}
-		   visitgraph : {PP_Doc}
-		   errors : {Seq Error} ]
+                   depgraphs : {PP_Doc}
+                   visitgraph : {PP_Doc}
+                   errors : {Seq Error} ]
 
 SEM  Grammar
   |  Grammar  (lhs.output, lhs.depgraphs, lhs.visitgraph, lhs.errors)

--- a/uuagc/trunk/src-ag/TfmToVisage.ag
+++ b/uuagc/trunk/src-ag/TfmToVisage.ag
@@ -114,23 +114,23 @@ SEM Production
       children.rulemap = @splitVRules
 
 SEM Children
-  | Cons	lhs.vchildren = @hd.vchild : @tl.vchildren
-  | Nil		lhs.vchildren = []
+  | Cons        lhs.vchildren = @hd.vchild : @tl.vchildren
+  | Nil         lhs.vchildren = []
 
 SEM Child
   | Child lhs.vchild = VChild @name @tp @loc.inh @loc.syn (getForField (getName @name) @lhs.rulemap)
 
 SEM Rules
-  | Cons	lhs.vrules = @hd.vrule : @tl.vrules
-  | Nil		lhs.vrules = []
+  | Cons        lhs.vrules = @hd.vrule : @tl.vrules
+  | Nil         lhs.vrules = []
 
 -- The undefined may seem strange, but it really belongs there.
 SEM Rule
   | Rule  lhs.vrule  = VRule @pattern.fieldattrs undefined @pattern.vpat @rhs.self @owrt
 
 SEM Patterns
-  | Cons	lhs.vpats = @hd.vpat : @tl.vpats
-  | Nil		lhs.vpats = []
+  | Cons        lhs.vpats = @hd.vpat : @tl.vpats
+  | Nil         lhs.vpats = []
 
 SEM Pattern
   | Constr      lhs.vpat = VConstr @name @pats.vpats

--- a/uuagc/trunk/src-ag/Visage.ag
+++ b/uuagc/trunk/src-ag/Visage.ag
@@ -55,8 +55,8 @@ SEM VisageGrammar
 
 
 SEM VisageNonterminals
-  | Cons 	lhs.aterms = @hd.aterm : @tl.aterms
-  | Nil		lhs.aterms = []
+  | Cons        lhs.aterms = @hd.aterm : @tl.aterms
+  | Nil         lhs.aterms = []
 
 
 SEM VisageNonterminal
@@ -65,8 +65,8 @@ SEM VisageNonterminal
 
 
 SEM VisageProductions
-  | Cons	lhs.aterms = @hd.aterm : @tl.aterms
-  | Nil		lhs.aterms = []
+  | Cons        lhs.aterms = @hd.aterm : @tl.aterms
+  | Nil         lhs.aterms = []
 
 
 SEM VisageProduction
@@ -77,8 +77,8 @@ SEM VisageProduction
                  rules.isLoc    = False
                                   
 SEM VisageChildren
-  | Cons	lhs.aterms = @hd.aterm : @tl.aterms
-  | Nil		lhs.aterms = []	
+  | Cons        lhs.aterms = @hd.aterm : @tl.aterms
+  | Nil         lhs.aterms = [] 
 
 
 SEM VisageChild
@@ -89,8 +89,8 @@ SEM VisageChild
                  rules.isLoc = False
                  
 SEM VisageRules
-  | Cons	lhs.aterms = @hd.aterm : @tl.aterms
-  | Nil		lhs.aterms = []
+  | Cons        lhs.aterms = @hd.aterm : @tl.aterms
+  | Nil         lhs.aterms = []
 
 
 SEM VisageRule
@@ -104,8 +104,8 @@ SEM Expression
 
 
 SEM VisagePatterns
-  | Cons	lhs.aterms = @hd.aterm : @tl.aterms
-  | Nil		lhs.aterms = []
+  | Cons        lhs.aterms = @hd.aterm : @tl.aterms
+  | Nil         lhs.aterms = []
 
 
 SEM VisagePattern

--- a/uuagc/trunk/src-generated/DefaultRules.hs
+++ b/uuagc/trunk/src-generated/DefaultRules.hs
@@ -137,7 +137,7 @@ buildConExpr ocaml clean conmap typeSyns rename nt con1 fs'
 
 concatSeq = foldr (Seq.><) Seq.empty
 
-splitAttrs :: Map Identifier a -> [Identifier] -> ([(Identifier,a)],[Identifier])	  -- a used as (String,String)
+splitAttrs :: Map Identifier a -> [Identifier] -> ([(Identifier,a)],[Identifier])         -- a used as (String,String)
 splitAttrs _      []
   =  ([],[])
 splitAttrs useMap (n:rest)
@@ -220,8 +220,8 @@ useRule opts locals ch_outs (n,(op,e,pos))
         isOp (c:cs)
           | isSpace c = isOp cs
           | isAlpha c = case dropWhile isAlpha cs of
-	    	           ('.':cs2) -> isOp cs2 -- fully qualified name, drop prefix
-			   _         -> False
+                           ('.':cs2) -> isOp cs2 -- fully qualified name, drop prefix
+                           _         -> False
           | c == '('  = False
           | otherwise = True
 

--- a/uuagc/trunk/src-generated/GenerateCode.hs
+++ b/uuagc/trunk/src-generated/GenerateCode.hs
@@ -202,9 +202,9 @@ isFirstOrder (ChildReplace tp) _  = Just tp
 makeLocalComment :: Int -> String -> Identifier -> Maybe Type -> String
 makeLocalComment width what  name tp = let  x = getName name
                                             y = maybe "_" (\t -> case t of
-					      	      (NT nt tps _) -> getName nt ++ " " ++ unwords tps
-					      	      Haskell t' -> '{' : t' ++ "}"
-						      Self -> error "Self type not allowed here.") tp
+                                                      (NT nt tps _) -> getName nt ++ " " ++ unwords tps
+                                                      Haskell t' -> '{' : t' ++ "}"
+                                                      Self -> error "Self type not allowed here.") tp
                                        in   ( what ++ " " ++ x ++ replicate ((width - length x) `max` 0) ' ' ++ " : " ++ y )
 
 {-# LINE 211 "dist/build/GenerateCode.hs" #-}

--- a/uuagc/trunk/src-generated/PrintErrorMessages.hs
+++ b/uuagc/trunk/src-generated/PrintErrorMessages.hs
@@ -91,7 +91,7 @@ showEdgeLong ((inh,syn),path1,path2)
 
 attrText :: Identifier -> Identifier -> String
 attrText inh syn
- = 	if   inh == syn
+ =      if   inh == syn
     then "threaded attribute " ++ getName inh
     else "inherited attribute " ++ getName inh ++ " and synthesized attribute " ++getName syn
 

--- a/uuagc/trunk/src/ATermAbstractSyntax.hs
+++ b/uuagc/trunk/src/ATermAbstractSyntax.hs
@@ -1,9 +1,9 @@
 {-----------------------------------------------------------------------------
 
-	Haskell ATerm Library
-		
-	Joost Visser
-	CWI, Amsterdam
+        Haskell ATerm Library
+                
+        Joost Visser
+        CWI, Amsterdam
 
   This module is part of the ATerm library for Haskell. It defines the
   abstract syntax of ATerms as a Haskell datatype.

--- a/uuagc/trunk/src/LOAG/Chordal.hs
+++ b/uuagc/trunk/src/LOAG/Chordal.hs
@@ -138,7 +138,13 @@ scheduleLOAG ag@(Ag nbounds pbounds dps nts) putStrLn opts = do
             f_idst <- freeze idst
             f_edp  <- freeze edp
             return ((f_idsf,f_idst),f_edp)
-         where  addEdges (f,t) es (idsf,idst) edp = do
+         where  addEdges
+                  :: (Vertex, Vertex)
+                  -> [(Vertex, Vertex)]
+                  -> (IOArray Vertex Vertices, IOArray Vertex Vertices)
+                  -> IOArray Vertex Vertices
+                  -> IO [()]
+                addEdges (f,t) es (idsf,idst) edp = do
                     modifyArray idsf f (t `IS.insert`)
                     modifyArray idst t (f `IS.insert`)
                     forM es $ \(f,t) -> do --edp does not reflect flow

--- a/uuagc/trunk/src/LOAG/Optimise.hs
+++ b/uuagc/trunk/src/LOAG/Optimise.hs
@@ -148,7 +148,7 @@ trySingle sat des f dir varMap = do
         vars <- tryExtreme sat des literals
         assertVars sat vars
         return True
- where  literals = M.foldWithKey select [] varMap
+ where  literals = M.foldrWithKey select [] varMap
         select k a b | fst k == f = a : b --inh
                      | snd k == f = varnot a : b --syn
                      | otherwise  = b
@@ -205,7 +205,11 @@ newSchedule sat varMap nbounds tp@(Nt nt _ _ inhs outs _ ) sched = do
         newsched | newmx < oldmx = newinterface
                  | otherwise     = sched
     return $ (newmx < oldmx, newsched)
- where  addEdges (f,t) (idsf,idst) = do
+ where  addEdges
+          :: (Vertex, Vertex)
+          -> (IOArray Vertex Vertices, IOArray Vertex Vertices)
+          -> IO ()
+        addEdges (f,t) (idsf,idst) = do
             modifyArray idsf f (t `IS.insert`)
             modifyArray idst t (f `IS.insert`)
  

--- a/uuagc/trunk/test/TestErr-CircLocal.ag
+++ b/uuagc/trunk/test/TestErr-CircLocal.ag
@@ -3,7 +3,7 @@
 --  a 1-cycle s that is not needed
 
 DATA Aap
-	| Een   t : Int
+        | Een   t : Int
 
 ATTR Aap [ | | z : Int ]
 

--- a/uuagc/trunk/test/TestErr-CyclicSet.ag
+++ b/uuagc/trunk/test/TestErr-CyclicSet.ag
@@ -1,6 +1,6 @@
 -- the set Noot is cyclic
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 SET Noot = Aap Noot

--- a/uuagc/trunk/test/TestErr-DupChild.ag
+++ b/uuagc/trunk/test/TestErr-DupChild.ag
@@ -1,5 +1,5 @@
 -- field a is declared twice
 
 DATA Aap 
-	| Een a : {Int}
-	      a : {Int}
+        | Een a : {Int}
+              a : {Int}

--- a/uuagc/trunk/test/TestErr-DupChild2.ag
+++ b/uuagc/trunk/test/TestErr-DupChild2.ag
@@ -3,7 +3,7 @@
 -- in v.0.9.3 this is allowed, but not with the same field
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 DATA Aap
-	| Een a : {Int}
+        | Een a : {Int}

--- a/uuagc/trunk/test/TestErr-DupRule.ag
+++ b/uuagc/trunk/test/TestErr-DupRule.ag
@@ -1,13 +1,13 @@
 -- attribute y is defined twice
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
 
 SEM Aap
-	| Een lhs.y = 3
+        | Een lhs.y = 3
 
 SEM Aap
-	| Een lhs.y = 4
-	
+        | Een lhs.y = 4
+        

--- a/uuagc/trunk/test/TestErr-DupSet.ag
+++ b/uuagc/trunk/test/TestErr-DupSet.ag
@@ -1,15 +1,15 @@
 -- set Noot is defined twice
 
 DATA Aap
-	| Een a : {Int}
-	
+        | Een a : {Int}
+        
 DATA Aap2
-	| Twee b : {Int}
-	
+        | Twee b : {Int}
+        
 DATA Aap3
-	| Drie c : {Int}
-	
-	
+        | Drie c : {Int}
+        
+        
 SET Noot = Aap Aap2
 
 SET Noot = Aap Aap2 Aap3

--- a/uuagc/trunk/test/TestErr-DupSet2.ag
+++ b/uuagc/trunk/test/TestErr-DupSet2.ag
@@ -1,12 +1,12 @@
 -- set Noot is also defined as a datatype
 
 DATA Aap
-	| Een a : {Int}
-	
+        | Een a : {Int}
+        
 DATA Aap2
-	| Twee b : {Int}
-	
+        | Twee b : {Int}
+        
 DATA Noot
-	| Vier d : {Int}
+        | Vier d : {Int}
 
 SET Noot = Aap Aap2

--- a/uuagc/trunk/test/TestErr-DupSyn2.ag
+++ b/uuagc/trunk/test/TestErr-DupSyn2.ag
@@ -1,8 +1,8 @@
 -- type synonym Noot is defined twice
 
 DATA Aap
-	| Een a : {Int}
-	
+        | Een a : {Int}
+        
 TYPE Noot = [Aap]
 
 TYPE Noot = (Aap,Aap)

--- a/uuagc/trunk/test/TestErr-MissingRule.ag
+++ b/uuagc/trunk/test/TestErr-MissingRule.ag
@@ -1,7 +1,7 @@
 -- the attribute y is declared but not defined
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
-	
+        

--- a/uuagc/trunk/test/TestErr-SuperflRule.ag
+++ b/uuagc/trunk/test/TestErr-SuperflRule.ag
@@ -1,10 +1,10 @@
 -- the attribute y is declared but not defined
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
-	
+        
 SEM Aap
-	| Een lhs.y = 3
-	      lhs.z = 4
+        | Een lhs.y = 3
+              lhs.z = 4

--- a/uuagc/trunk/test/TestErr-UndefAlt.ag
+++ b/uuagc/trunk/test/TestErr-UndefAlt.ag
@@ -1,10 +1,10 @@
 -- an attribute is defined for a non-existing alternative
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
 
 SEM Aap
-	| Twee lhs.y = 3
-	
+        | Twee lhs.y = 3
+        

--- a/uuagc/trunk/test/TestErr-UndefAttr.ag
+++ b/uuagc/trunk/test/TestErr-UndefAttr.ag
@@ -1,9 +1,9 @@
 -- the used attribute x is not declared
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
-	
+        
 SEM Aap
-	| Een lhs.y = @lhs.x
+        | Een lhs.y = @lhs.x

--- a/uuagc/trunk/test/TestErr-UndefChild.ag
+++ b/uuagc/trunk/test/TestErr-UndefChild.ag
@@ -1,10 +1,10 @@
 -- an attribute is defined for a non-existing child
 
 DATA Aap 
-	| Een a : Aap
+        | Een a : Aap
 
 ATTR Aap [ x : {Int} | | ]
 
 SEM Aap
-	| Een b.x = 3
-	
+        | Een b.x = 3
+        

--- a/uuagc/trunk/test/TestErr-UndefChild2.ag
+++ b/uuagc/trunk/test/TestErr-UndefChild2.ag
@@ -1,10 +1,10 @@
 -- an attribute is defined for a child that is not a nonterminal
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ x : {Int} | | ]
 
 SEM Aap
-	| Een a.x = 3
-	
+        | Een a.x = 3
+        

--- a/uuagc/trunk/test/TestErr-UndefLocal.ag
+++ b/uuagc/trunk/test/TestErr-UndefLocal.ag
@@ -1,9 +1,9 @@
 -- the local variabele i is not defined
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
-	
+        
 SEM Aap
-	| Een lhs.y = @i
+        | Een lhs.y = @i

--- a/uuagc/trunk/test/TestErr-UndefNont.ag
+++ b/uuagc/trunk/test/TestErr-UndefNont.ag
@@ -1,7 +1,7 @@
 -- an attribute is declared for a non-existing type
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Noot [ | | y : {Int} ]
-	
+        

--- a/uuagc/trunk/test/TestErr-UndefNont2.ag
+++ b/uuagc/trunk/test/TestErr-UndefNont2.ag
@@ -1,10 +1,10 @@
 -- a synthesized attribute is defined for a non-existing type
 
 DATA Aap 
-	| Een a : {Int}
+        | Een a : {Int}
 
 ATTR Aap [ | | y : {Int} ]
 
 SEM Noot
-	| Een lhs.y = 3
-	
+        | Een lhs.y = 3
+        

--- a/uuagc/trunk/test/TestErr-UndefNont3.ag
+++ b/uuagc/trunk/test/TestErr-UndefNont3.ag
@@ -2,4 +2,4 @@
 
 SEM Noot
   | Een a.y = 3
-      	
+        

--- a/uuagc/trunk/test/TestErrBareChild.ag
+++ b/uuagc/trunk/test/TestErrBareChild.ag
@@ -7,8 +7,8 @@ DATA Noot
   | Two
   
 DATA Aap 
-	| Een child : Noot
-	
+        | Een child : Noot
+        
 ATTR Aap [ | | synth : Noot ]
 
 SEM Aap

--- a/uuagc/trunk/test/TestErrDupSig.ag
+++ b/uuagc/trunk/test/TestErrDupSig.ag
@@ -1,7 +1,7 @@
 -- Local variable with explicit type signature (new syntax introduced in "sequential")
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 SEM Aap
    | Een loc.x : {Int}

--- a/uuagc/trunk/test/TestErrOK-DupAlt.ag
+++ b/uuagc/trunk/test/TestErrOK-DupAlt.ag
@@ -3,7 +3,7 @@
 -- in v.0.9.3 it is allowed, as long as the childs are different
 
 DATA Aap
-	| Een  a : {Int}
-	| Twee b : {Int}
-	| Twee c : {Int}
-	| Drie d : {Int}	
+        | Een  a : {Int}
+        | Twee b : {Int}
+        | Twee c : {Int}
+        | Drie d : {Int}        

--- a/uuagc/trunk/test/TestErrOK-DupAlt2.ag
+++ b/uuagc/trunk/test/TestErrOK-DupAlt2.ag
@@ -3,11 +3,11 @@
 -- in v.0.9.3 it is allowed, as long as the childs are different
 
 DATA Aap
-	| Een  a : {Int}
-	| Twee b : {Int}
+        | Een  a : {Int}
+        | Twee b : {Int}
 
 DATA Noot
-	| One  d : {Int}
-	
+        | One  d : {Int}
+        
 DATA Aap
-	| Twee c : {Int}	
+        | Twee c : {Int}        

--- a/uuagc/trunk/test/TestErrOK-DupSet3.ag
+++ b/uuagc/trunk/test/TestErrOK-DupSet3.ag
@@ -3,12 +3,12 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Twee b : {Int}
-	
+        | Twee b : {Int}
+        
 SET Both = Aap Noot
 
 DATA Both
-	| Drie c : {Int}
+        | Drie c : {Int}

--- a/uuagc/trunk/test/TestErrOK-DupSyn3.ag
+++ b/uuagc/trunk/test/TestErrOK-DupSyn3.ag
@@ -3,9 +3,9 @@
 -- in v.0.9.3 this is really allowed, and the error message is changed accordingly
 
 DATA Aap
-	| Een a : {Int}
-	
+        | Een a : {Int}
+        
 TYPE Noot = [Aap]
 
 DATA Noot
-	| Twee b : {Int}
+        | Twee b : {Int}

--- a/uuagc/trunk/test/TestErrOK-PolyData.ag
+++ b/uuagc/trunk/test/TestErrOK-PolyData.ag
@@ -3,10 +3,10 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Twee b : {Int}
-	
+        | Twee b : {Int}
+        
 DATA Aap Noot
-	| Drie c : {Int}
+        | Drie c : {Int}

--- a/uuagc/trunk/test/TestErrOK-PolyData2.ag
+++ b/uuagc/trunk/test/TestErrOK-PolyData2.ag
@@ -3,10 +3,10 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Twee b : {Int}
-	
+        | Twee b : {Int}
+        
 DATA *
-	| Drie c : {Int}
+        | Drie c : {Int}

--- a/uuagc/trunk/test/TestErrOK-PolySem.ag
+++ b/uuagc/trunk/test/TestErrOK-PolySem.ag
@@ -3,14 +3,14 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Een b : {Int}
+        | Een b : {Int}
 
 SET Both = Aap Noot 
 
 ATTR Both [ | | y : {Int} ]
 
 SEM Both
-	| Een  lhs.y = 3
+        | Een  lhs.y = 3

--- a/uuagc/trunk/test/TestErrOK-PolySem2.ag
+++ b/uuagc/trunk/test/TestErrOK-PolySem2.ag
@@ -3,12 +3,12 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Een b : {Int}
+        | Een b : {Int}
 
 ATTR Aap Noot [ | | y : {Int} ]
 
 SEM Aap Noot
-	| Een  lhs.y = 3
+        | Een  lhs.y = 3

--- a/uuagc/trunk/test/TestErrOK-PolySem3.ag
+++ b/uuagc/trunk/test/TestErrOK-PolySem3.ag
@@ -3,13 +3,13 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Een b : {Int}
-	| Twee c : {Int}
+        | Een b : {Int}
+        | Twee c : {Int}
 
 ATTR Aap Noot [ | | y : {Int} ]
 
 SEM Aap Noot
-	| * lhs.y = 3
+        | * lhs.y = 3

--- a/uuagc/trunk/test/TestErrOK-PolySem4.ag
+++ b/uuagc/trunk/test/TestErrOK-PolySem4.ag
@@ -3,13 +3,13 @@
 -- in v.0.9.3 it is allowed
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 DATA Noot
-	| Een b : {Int}
-	| Twee c : {Int}
+        | Een b : {Int}
+        | Twee c : {Int}
 
 ATTR Aap Noot [ | | y : {Int} ]
 
 SEM *
-	| * lhs.y = 3
+        | * lhs.y = 3

--- a/uuagc/trunk/test/TestErrOK-ShareAlt.ag
+++ b/uuagc/trunk/test/TestErrOK-ShareAlt.ag
@@ -3,8 +3,8 @@
 -- in v.0.9.3 it is possible
 
 DATA Both
-	| Een  a : {Int}
-	| Twee b : {Int}
+        | Een  a : {Int}
+        | Twee b : {Int}
 
 SET Both = Aap Noot
 

--- a/uuagc/trunk/test/TestOK-DupAlt3.ag
+++ b/uuagc/trunk/test/TestOK-DupAlt3.ag
@@ -3,11 +3,11 @@
 -- in v.0.9.3 it is allowed, as long as the childs are different
 
 DATA Aap
-	| Een  a : {Int}
-	| Twee b : {Int}
+        | Een  a : {Int}
+        | Twee b : {Int}
 
 DATA Noot
-	| One  d : {Int}
-	
+        | One  d : {Int}
+        
 DATA Aap
-	| Drie c : {Int}	
+        | Drie c : {Int}        

--- a/uuagc/trunk/test/TestOK-Literate.lag
+++ b/uuagc/trunk/test/TestOK-Literate.lag
@@ -3,13 +3,13 @@ Two ways of grouping code in literate mode
 The first way is with uppercase Code, which is possible for quite some time already
 \begin{Code}
 DATA Aap
-	| Een   x : Int
+        | Een   x : Int
 \end{Code}
 
 The second way is with lowercase code, which is the convention used in Haskell
 \begin{code}
 DATA Noot
-	| Twee   y : Int
+        | Twee   y : Int
 \end{code}
 
 bla bla

--- a/uuagc/trunk/test/TestOK-NestedTupel.ag
+++ b/uuagc/trunk/test/TestOK-NestedTupel.ag
@@ -1,7 +1,7 @@
 -- A grammar that has local attributes defined in a nested record
 
 DATA Aap
-	| Een   t : Int
+        | Een   t : Int
 
 ATTR Aap [ | | y:Int   z:Int ]
 

--- a/uuagc/trunk/test/TestOKBareTrivChild.ag
+++ b/uuagc/trunk/test/TestOKBareTrivChild.ag
@@ -2,8 +2,8 @@
 -- which is allowed because its type is not a Nonterminal
 
 DATA Aap 
-	| Een child : Int
-	
+        | Een child : Int
+        
 ATTR Aap [ | | synth : Int ]
 
 SEM Aap

--- a/uuagc/trunk/test/TestOKSelfChild.ag
+++ b/uuagc/trunk/test/TestOKSelfChild.ag
@@ -8,8 +8,8 @@ DATA Noot
 ATTR Noot [ | | self : SELF ]
 
 DATA Aap 
-	| Een child : Noot
-	
+        | Een child : Noot
+        
 ATTR Aap [ | | synth : Noot ]
 
 SEM Aap

--- a/uuagc/trunk/test/TestOKVisit1.ag
+++ b/uuagc/trunk/test/TestOKVisit1.ag
@@ -4,7 +4,7 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een
+        | Een
 
 ATTR Root [ | | z : Int ]
 ATTR Aap [ x : Int | | y : Int z : Int ]

--- a/uuagc/trunk/test/TestOKVisit2.ag
+++ b/uuagc/trunk/test/TestOKVisit2.ag
@@ -4,8 +4,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Int
+        | Een   t : Int
+        | Twee  u : Int
 
 
 ATTR Aap [ x : Int | y : Int  |  s : SELF ]

--- a/uuagc/trunk/test/TestOKVisit3.ag
+++ b/uuagc/trunk/test/TestOKVisit3.ag
@@ -5,8 +5,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Int
+        | Een   t : Int
+        | Twee  u : Int
 
 
 ATTR Aap [ x : Int | y : Int  |  s : SELF ]

--- a/uuagc/trunk/test/TestOKVisitInst1.ag
+++ b/uuagc/trunk/test/TestOKVisitInst1.ag
@@ -4,7 +4,7 @@ DATA Root
    | Root
 
 DATA Aap
-	| Een
+        | Een
 
 ATTR Root [ | | z : Int ]
 ATTR Aap [ x : Int | | y : Int z : Int ]

--- a/uuagc/trunk/test/TestOkSig.ag
+++ b/uuagc/trunk/test/TestOkSig.ag
@@ -1,7 +1,7 @@
 -- Local variable with explicit type signature (new syntax introduced in "sequential")
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 SEM Aap
    | Een loc.x : {Int}

--- a/uuagc/trunk/test/TestOkSigs.ag
+++ b/uuagc/trunk/test/TestOkSigs.ag
@@ -2,7 +2,7 @@
 -- for multiple variables, possibly extending multiple lines, with or without braces
 
 DATA Aap
-	| Een  a : {Int}
+        | Een  a : {Int}
 
 SEM Aap
    | Een loc.x : {Int 

--- a/uuagc/trunk/test/TestOkTupVis1.ag
+++ b/uuagc/trunk/test/TestOkTupVis1.ag
@@ -7,8 +7,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Aap
+        | Een   t : Int
+        | Twee  u : Aap
 
 
 ATTR Aap [ x : Int | y : Int |  z : Int   w : Int ]

--- a/uuagc/trunk/test/TestOkTupVis2.ag
+++ b/uuagc/trunk/test/TestOkTupVis2.ag
@@ -10,8 +10,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Aap
+        | Een   t : Int
+        | Twee  u : Aap
 
 
 ATTR Aap [ x : Int | y : Int |  z : Int   w : Int ]

--- a/uuagc/trunk/test/TestOkTupVis3.ag
+++ b/uuagc/trunk/test/TestOkTupVis3.ag
@@ -13,8 +13,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Aap
+        | Een   t : Int
+        | Twee  u : Aap
 
 
 ATTR Aap [ x : Int | y : Int |  z : Int   w : Int ]

--- a/uuagc/trunk/test/TestOkTupVis4.ag
+++ b/uuagc/trunk/test/TestOkTupVis4.ag
@@ -17,8 +17,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Aap
+        | Een   t : Int
+        | Twee  u : Aap
 
 
 ATTR Aap [ x : Int | y : Int |  z : Int   w : Int  zz : Int]

--- a/uuagc/trunk/test/TestOkVisit4.ag
+++ b/uuagc/trunk/test/TestOkVisit4.ag
@@ -7,8 +7,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Aap
+        | Een   t : Int
+        | Twee  u : Aap
 
 
 ATTR Aap [ x : Int | y : Int |  z : Int   w : Int ]

--- a/uuagc/trunk/test/TestOkVisit5.ag
+++ b/uuagc/trunk/test/TestOkVisit5.ag
@@ -5,8 +5,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Aap
+        | Een   t : Int
+        | Twee  u : Aap
 
 
 ATTR Aap [ x : Int | y : Int |  z : Int   s : SELF ]

--- a/uuagc/trunk/test/TestOkVisit6.ag
+++ b/uuagc/trunk/test/TestOkVisit6.ag
@@ -5,8 +5,8 @@ DATA Root
    | Root  a : Aap
 
 DATA Aap
-	| Een   t : Int
-	| Twee  u : Noot
+        | Een   t : Int
+        | Twee  u : Noot
 
 DATA Noot
     | Drie  v : Aap

--- a/uuagc/trunk/uuagc.cabal
+++ b/uuagc/trunk/uuagc.cabal
@@ -34,7 +34,7 @@ flag with-loag
    manual: True
 
 custom-setup
-  setup-depends: base, Cabal
+  setup-depends: base, Cabal, uuagc-cabal
 
 executable uuagc
    build-depends: uuagc-cabal >= 1.0.2.0


### PR DESCRIPTION
I think the `-DEXTERNAL_UUAGC` flag is necessary if you want to make changes to any of the .ag files (which I plan to do).

The expansion of tabs (to 8 spaces) is better for portability, because some systems choose a different tab width (such as here on GitHub).

EDIT: I have now also fixed some errors that occur when building with the `with-loag` flag. Some types got inferred too generally which would require `FlexibleContexts`, but I simply added the explicit concrete type signature. And one function got renamed.