### PR TITLE
Fix incompatibility with GHC 9.2 and 9.4

### DIFF
--- a/uuagc/trunk/cabal-plugin/src/Distribution/Simple/UUAGC/UUAGC.hs
+++ b/uuagc/trunk/cabal-plugin/src/Distribution/Simple/UUAGC/UUAGC.hs
@@ -265,6 +265,10 @@ uuagc' :: ([String] -> FilePath -> IO (ExitCode, [FilePath]))
         -> PreProcessor
 uuagc' uuagc build lbi _ =
    PreProcessor {
+#if MIN_VERSION_Cabal(3,8,1)
+     --  The ppOrdering field was added in Cabal 3.8.1 (GHC 9.4)
+     ppOrdering = \_verbosity _files modules -> pure modules,
+#endif
      platformIndependent = True,
      runPreProcessor = mkSimplePreProcessor $ \ inFile outFile verbosity ->
                        do notice verbosity $ "[UUAGC] processing: " ++ inFile ++ " generating: " ++ outFile
@@ -297,6 +301,10 @@ hsSourceDirsFilePaths = id
 nouuagc :: BuildInfo -> LocalBuildInfo -> ComponentLocalBuildInfo -> PreProcessor
 nouuagc build lbi _ =
   PreProcessor {
+#if MIN_VERSION_Cabal(3,8,1)
+     --  The ppOrdering field was added in Cabal 3.8.1 (GHC 9.4)
+     ppOrdering = \_verbosity _files modules -> pure modules,
+#endif
     platformIndependent = True,
     runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity -> do
       info verbosity ("skipping: " ++ outFile)

--- a/uuagc/trunk/cabal-plugin/src/Distribution/Simple/UUAGC/UUAGC.hs
+++ b/uuagc/trunk/cabal-plugin/src/Distribution/Simple/UUAGC/UUAGC.hs
@@ -134,7 +134,7 @@ updateAGFile uuagc newOptions (file,(opts,Just (gen,sp))) = do
     (ec, files) <- uuagc (optionsToString $ opts { genFileDeps = True, searchPath = sp }) file
     case ec of
       ExitSuccess -> do
-        let newOpts :: Options 
+        let newOpts :: Options
             newOpts = maybe noOptions fst $ Map.lookup file newOptions
             optRebuild = optionsToString newOpts /= optionsToString opts
         modRebuild <-

--- a/uuagc/trunk/src/KennedyWarren.hs
+++ b/uuagc/trunk/src/KennedyWarren.hs
@@ -281,7 +281,8 @@ type VG s a = ErrorT String (StateT (VGState s) (ST s)) a
 ------------------------------------------------------------
 -- | Run the VG monad in the ST monad
 runVG :: VG s a -> ST s a
-runVG vg = do (Right a,_) <- runStateT (runErrorT vg) vgEmptyState
+runVG vg = do result <- runStateT (runErrorT vg) vgEmptyState
+              let (Right a,_) = result
               return a
 
 -- | Insert an initial node for this nonterminal into the visit graph


### PR DESCRIPTION
In a Haskell Meetup somewhere last year, @jbransen and I discussed this wonderful gem. I see that it doesn't have many recent commits, so I'd love to help here and there to keep it up-to-date. One reason for this is that a [hobby project](https://github.com/FPtje/GLuaFixer) of mine _heavily_ relies on this library.

This PR brings UUAGC up to date with GHC 9.2 and GHC 9.4. The individual commits describe the different changes made. Tested with GHC 9.0, 9.2 and 9.4. Also tested with glualint on GHC 9.2.

I would have liked to try and fix it up for GHC 9.6 as well, but there are just way too many dependencies that fail to build. I guess we'll have to wait for that to settle down first :). 

If desired, I can fix up and make a PR for a quick [Nix flake](https://github.com/FPtje/uuagc/commit/e32b1dd24aa99a20ed57e1b435e728f17c97ee36) that I wrote to run these tests.